### PR TITLE
Fix stale download settings and segment status

### DIFF
--- a/app/shared/src/commonMain/kotlin/com/linroid/ketch/app/ui/common/SpeedLimitSlider.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/ketch/app/ui/common/SpeedLimitSlider.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -193,8 +194,9 @@ fun SpeedLimitPanel(
   scope: CoroutineScope,
   modifier: Modifier = Modifier,
 ) {
+  val request by task.requestState.collectAsState()
   SpeedLimitSelector(
-    value = task.request.speedLimit,
+    value = request.speedLimit,
     onValueChange = { limit ->
       scope.launch { task.setSpeedLimit(limit) }
     },

--- a/app/shared/src/commonMain/kotlin/com/linroid/ketch/app/ui/common/TaskSettingsPanel.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/ketch/app/ui/common/TaskSettingsPanel.kt
@@ -51,6 +51,7 @@ fun TaskSettingsPanel(
   task: DownloadTask,
   modifier: Modifier = Modifier,
 ) {
+  val request by task.requestState.collectAsState()
   val segments by task.segments.collectAsState()
 
   Surface(
@@ -62,16 +63,16 @@ fun TaskSettingsPanel(
       modifier = Modifier.padding(12.dp),
       verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-      CopyableInfoRow("URL", task.request.url)
+      CopyableInfoRow("URL", request.url)
 
-      task.request.destination?.let { dest ->
+      request.destination?.let { dest ->
         InfoRow("Destination", dest.value)
       }
 
       InfoRow(
         "Connections",
-        if (task.request.connections > 0) {
-          task.request.connections.toString()
+        if (request.connections > 0) {
+          request.connections.toString()
         } else {
           "Auto"
         }
@@ -85,9 +86,9 @@ fun TaskSettingsPanel(
       }
       InfoRow(
         "Priority",
-        priorityLabel(task.request.priority)
+        priorityLabel(request.priority)
       )
-      val limit = task.request.speedLimit
+      val limit = request.speedLimit
       InfoRow(
         "Speed limit",
         if (limit.isUnlimited) "Unlimited"

--- a/app/shared/src/commonMain/kotlin/com/linroid/ketch/app/ui/list/DownloadListItem.kt
+++ b/app/shared/src/commonMain/kotlin/com/linroid/ketch/app/ui/list/DownloadListItem.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import com.linroid.ketch.api.DownloadPriority
 import com.linroid.ketch.api.DownloadState
 import com.linroid.ketch.api.DownloadTask
+import com.linroid.ketch.api.SpeedLimit
 import com.linroid.ketch.api.isName
 import com.linroid.ketch.app.components.KetchIconButton
 import com.linroid.ketch.app.components.KetchFileTypeChip
@@ -79,16 +80,17 @@ fun DownloadListItem(
   scope: CoroutineScope,
   modifier: Modifier = Modifier,
 ) {
+  val request by task.requestState.collectAsState()
   val state by task.state.collectAsState()
   val segments by task.segments.collectAsState()
-  val dest = task.request.destination
-  val fileName = remember(task.taskId, dest, task.request.url) {
+  val dest = request.destination
+  val fileName = remember(task.taskId, dest, request.url) {
     val raw = when {
       dest != null && dest.isName() -> dest.value
       dest != null -> extractFilename(dest.value).ifBlank { null }
       else -> null
     }
-    raw ?: extractFilename(task.request.url).ifBlank { "download" }
+    raw ?: extractFilename(request.url).ifBlank { "download" }
   }
 
   var expanded by remember { mutableStateOf(false) }
@@ -193,6 +195,7 @@ private fun DownloadRow(
   expanded: Boolean,
   onToggle: () -> Unit,
 ) {
+  val request by task.requestState.collectAsState()
   val colors = KetchTheme.colors
   val type = KetchTheme.typography
   val progress = stateProgress(state)
@@ -225,9 +228,9 @@ private fun DownloadRow(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f, fill = false),
           )
-          if (task.request.priority != DownloadPriority.NORMAL) {
+          if (request.priority != DownloadPriority.NORMAL) {
             Spacer(Modifier.width(8.dp))
-            PriorityBadge(task.request.priority)
+            PriorityBadge(request.priority)
           }
         }
         if (state is DownloadState.Downloading || state is DownloadState.Paused) KetchProgressBar(
@@ -237,14 +240,14 @@ private fun DownloadRow(
         if (compact) {
           FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             StatusPill(state = state, foreground = stateColors.foreground)
-            PrimaryMetric(state = state)
+            PrimaryMetric(state = state, speedLimit = request.speedLimit)
           }
         }
       }
 
       // Primary metric (mono)
       if (!compact) {
-        PrimaryMetric(state = state)
+        PrimaryMetric(state = state, speedLimit = request.speedLimit)
         StatusPill(state = state, foreground = stateColors.foreground)
       }
 
@@ -255,13 +258,18 @@ private fun DownloadRow(
 }
 
 @Composable
-private fun PrimaryMetric(state: DownloadState) {
+private fun PrimaryMetric(state: DownloadState, speedLimit: SpeedLimit) {
   val colors = KetchTheme.colors
   val type = KetchTheme.typography
   val text = when (state) {
     is DownloadState.Downloading -> {
       val p = state.progress
-      val speed = if (p.bytesPerSecond > 0) "${formatBytes(p.bytesPerSecond)}/s" else "--"
+      val speed = buildString {
+        append(if (p.bytesPerSecond > 0) "${formatBytes(p.bytesPerSecond)}/s" else "--")
+        if (!speedLimit.isUnlimited) {
+          append(" (limit: ${formatBytes(speedLimit.bytesPerSecond)}/s)")
+        }
+      }
       val eta = if (p.bytesPerSecond > 0 && p.totalBytes > 0) {
         val remaining = (p.totalBytes - p.downloadedBytes).coerceAtLeast(0)
         formatEta(remaining / p.bytesPerSecond)
@@ -374,6 +382,7 @@ private fun ExpandedSettingsRow(
   onRemoveRequest: () -> Unit,
   onCancel: () -> Unit,
 ) {
+  val request by task.requestState.collectAsState()
   val state by task.state.collectAsState()
   val canConfigure = state is DownloadState.Downloading ||
     state is DownloadState.Paused ||
@@ -395,12 +404,12 @@ private fun ExpandedSettingsRow(
   ) {
     if (canConfigure) {
       SpeedLimitIcon(
-        active = !task.request.speedLimit.isUnlimited,
+        active = !request.speedLimit.isUnlimited,
         selected = subPanel == ExpandedSubPanel.SpeedLimit,
         onClick = { toggle(ExpandedSubPanel.SpeedLimit) },
       )
       PriorityIcon(
-        active = task.request.priority != DownloadPriority.NORMAL,
+        active = request.priority != DownloadPriority.NORMAL,
         selected = subPanel == ExpandedSubPanel.Priority,
         onClick = { toggle(ExpandedSubPanel.Priority) },
       )

--- a/library/api/src/commonMain/kotlin/com/linroid/ketch/api/DownloadTask.kt
+++ b/library/api/src/commonMain/kotlin/com/linroid/ketch/api/DownloadTask.kt
@@ -8,7 +8,8 @@ import kotlin.time.Instant
  * Represents a download task with reactive state and control methods.
  *
  * @property taskId Unique identifier for this download task
- * @property request The download request configuration
+ * @property request The current download request configuration
+ * @property requestState Observable download request configuration, including runtime changes
  * @property createdAt Timestamp when the task was created
  * @property state Observable download state
  * @property segments Observable list of download segments with their progress
@@ -16,6 +17,7 @@ import kotlin.time.Instant
 interface DownloadTask {
   val taskId: String
   val request: DownloadRequest
+  val requestState: StateFlow<DownloadRequest>
   val createdAt: Instant
   val state: StateFlow<DownloadState>
   val segments: StateFlow<List<Segment>>

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/task/RealDownloadTask.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/task/RealDownloadTask.kt
@@ -17,7 +17,7 @@ import kotlin.time.Instant
 
 internal class RealDownloadTask(
   override val taskId: String,
-  override val request: DownloadRequest,
+  request: DownloadRequest,
   override val createdAt: Instant,
   initialState: DownloadState,
   initialSegments: List<Segment>,
@@ -25,13 +25,20 @@ internal class RealDownloadTask(
   taskStore: TaskStore,
   record: TaskRecord,
 ) : DownloadTask, TaskHandle {
+  private val mutableRequest = MutableStateFlow(request)
+  override val requestState: StateFlow<DownloadRequest> = mutableRequest.asStateFlow()
+  override val request: DownloadRequest get() = requestState.value
+
   override val mutableState = MutableStateFlow(initialState)
   override val mutableSegments = MutableStateFlow(initialSegments)
 
   override val state: StateFlow<DownloadState> = mutableState.asStateFlow()
   override val segments: StateFlow<List<Segment>> = mutableSegments.asStateFlow()
 
-  override val record = AtomicSaver(record) { taskStore.save(it) }
+  override val record = AtomicSaver(record) {
+    taskStore.save(it)
+    mutableRequest.value = it.request
+  }
 
   private val log = KetchLogger("DownloadTask")
 

--- a/library/core/src/commonTest/kotlin/com/linroid/ketch/task/RealDownloadTaskTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/ketch/task/RealDownloadTaskTest.kt
@@ -1,0 +1,70 @@
+package com.linroid.ketch.task
+
+import com.linroid.ketch.api.Destination
+import com.linroid.ketch.api.DownloadCondition
+import com.linroid.ketch.api.DownloadPriority
+import com.linroid.ketch.api.DownloadRequest
+import com.linroid.ketch.api.DownloadSchedule
+import com.linroid.ketch.api.DownloadState
+import com.linroid.ketch.api.SpeedLimit
+import com.linroid.ketch.core.task.InMemoryTaskStore
+import com.linroid.ketch.core.task.RealDownloadTask
+import com.linroid.ketch.core.task.TaskController
+import com.linroid.ketch.core.task.TaskHandle
+import com.linroid.ketch.core.task.TaskRecord
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+class RealDownloadTaskTest {
+  @Test
+  fun recordUpdate_settingsChange_publishesCurrentRequest() = runTest {
+    val request = DownloadRequest(url = "https://example.com/file")
+    val now = Instant.fromEpochMilliseconds(0)
+    val task = RealDownloadTask(
+      taskId = "task",
+      request = request,
+      createdAt = now,
+      initialState = DownloadState.Queued,
+      initialSegments = emptyList(),
+      controller = UnusedController,
+      taskStore = InMemoryTaskStore(),
+      record = TaskRecord(
+        taskId = "task",
+        request = request,
+        createdAt = now,
+        updatedAt = now,
+      ),
+    )
+    val changed = async { task.requestState.first { it != request } }
+    val updated = request.copy(speedLimit = SpeedLimit.of(1024), connections = 2)
+
+    task.record.update { it.copy(request = updated) }
+
+    assertEquals(updated, changed.await())
+    assertEquals(updated, task.request)
+    assertEquals(DownloadState.Queued, task.state.value)
+  }
+
+  private object UnusedController : TaskController {
+    override suspend fun pause(taskId: String) = error("Unexpected call")
+    override suspend fun resume(handle: TaskHandle, destination: Destination?) =
+      error("Unexpected call")
+    override suspend fun cancel(handle: TaskHandle) = error("Unexpected call")
+    override suspend fun remove(handle: TaskHandle, deleteFiles: Boolean) = error("Unexpected call")
+    override suspend fun setSpeedLimit(taskId: String, limit: SpeedLimit) =
+      error("Unexpected call")
+    override suspend fun setConnections(taskId: String, connections: Int) =
+      error("Unexpected call")
+    override suspend fun setPriority(taskId: String, priority: DownloadPriority) =
+      error("Unexpected call")
+    override suspend fun reschedule(
+      handle: TaskHandle,
+      schedule: DownloadSchedule,
+      conditions: List<DownloadCondition>,
+    ) = error("Unexpected call")
+  }
+}

--- a/library/endpoints/src/commonMain/kotlin/com/linroid/ketch/endpoints/model/TaskEvent.kt
+++ b/library/endpoints/src/commonMain/kotlin/com/linroid/ketch/endpoints/model/TaskEvent.kt
@@ -1,6 +1,8 @@
 package com.linroid.ketch.endpoints.model
 
+import com.linroid.ketch.api.DownloadRequest
 import com.linroid.ketch.api.DownloadState
+import com.linroid.ketch.api.Segment
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -38,20 +40,30 @@ sealed class TaskEvent {
     override val taskId: String,
   ) : TaskEvent()
 
-  /** A task's state changed (non-progress update). */
+  /**
+   * A task's state, settings, or segments changed (non-progress update).
+   * Null request or segments indicate an older server that omitted those fields.
+   */
   @Serializable
   @SerialName("state_changed")
   data class StateChanged(
     override val taskId: String,
     val state: DownloadState,
+    val request: DownloadRequest? = null,
+    val segments: List<Segment>? = null,
   ) : TaskEvent()
 
-  /** Download progress update. */
+  /**
+   * Download progress, settings, or segment update for an active download.
+   * Null request or segments indicate an older server that omitted those fields.
+   */
   @Serializable
   @SerialName("progress")
   data class Progress(
     override val taskId: String,
     val state: DownloadState,
+    val request: DownloadRequest? = null,
+    val segments: List<Segment>? = null,
   ) : TaskEvent()
 
   /** Server error for a task. */

--- a/library/remote/src/commonMain/kotlin/com/linroid/ketch/remote/RemoteDownloadTask.kt
+++ b/library/remote/src/commonMain/kotlin/com/linroid/ketch/remote/RemoteDownloadTask.kt
@@ -32,13 +32,17 @@ import kotlin.time.Instant
 
 internal class RemoteDownloadTask(
   override val taskId: String,
-  override val request: DownloadRequest,
+  request: DownloadRequest,
   override val createdAt: Instant,
   initialState: DownloadState,
   initialSegments: List<Segment>,
   private val httpClient: HttpClient,
   private val onRemoved: suspend (String) -> Unit,
 ) : DownloadTask {
+  private val mutableRequest = MutableStateFlow(request)
+  override val requestState: StateFlow<DownloadRequest> = mutableRequest.asStateFlow()
+  override val request: DownloadRequest get() = requestState.value
+
   private val log = KetchLogger("RemoteTask")
 
   private val _state = MutableStateFlow(initialState)
@@ -48,7 +52,13 @@ internal class RemoteDownloadTask(
   override val segments: StateFlow<List<Segment>> =
     _segments.asStateFlow()
 
-  internal fun updateState(newState: DownloadState) {
+  internal fun updateState(
+    newState: DownloadState,
+    request: DownloadRequest? = null,
+    segments: List<Segment>? = null,
+  ) {
+    request?.let { mutableRequest.value = it }
+    segments?.let { _segments.value = it }
     log.d { "State update for taskId=$taskId: $newState" }
     _state.value = newState
   }
@@ -137,8 +147,7 @@ internal class RemoteDownloadTask(
   }
 
   private fun update(response: TaskSnapshot) {
-    _state.value = response.state
-    _segments.value = response.segments
+    updateState(response.state, response.request, response.segments)
   }
 
   private fun checkSuccess(

--- a/library/remote/src/commonMain/kotlin/com/linroid/ketch/remote/RemoteKetch.kt
+++ b/library/remote/src/commonMain/kotlin/com/linroid/ketch/remote/RemoteKetch.kt
@@ -263,14 +263,14 @@ class RemoteKetch(
         val task = taskMutex.withLock {
           taskMap[event.taskId]
         } ?: return
-        task.updateState(event.state)
+        task.updateState(event.state, event.request, event.segments)
       }
 
       is TaskEvent.Progress -> {
         val task = taskMutex.withLock {
           taskMap[event.taskId]
         } ?: return
-        task.updateState(event.state)
+        task.updateState(event.state, event.request, event.segments)
       }
 
       is TaskEvent.Error -> {

--- a/library/remote/src/commonTest/kotlin/com/linroid/ketch/remote/RemoteDownloadTaskTest.kt
+++ b/library/remote/src/commonTest/kotlin/com/linroid/ketch/remote/RemoteDownloadTaskTest.kt
@@ -1,0 +1,69 @@
+package com.linroid.ketch.remote
+
+import com.linroid.ketch.api.DownloadRequest
+import com.linroid.ketch.api.DownloadState
+import com.linroid.ketch.api.Segment
+import com.linroid.ketch.api.SpeedLimit
+import com.linroid.ketch.endpoints.model.TaskSnapshot
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.resources.Resources
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+class RemoteDownloadTaskTest {
+  @Test
+  fun setSpeedLimit_response_updatesRequestAndSegmentsWithoutStateChange() = runTest {
+    val original = DownloadRequest(url = "https://example.com/file")
+    val updated = original.copy(speedLimit = SpeedLimit.of(1024), connections = 1)
+    val segments = listOf(Segment(0, 0, 99, 50))
+    val now = Instant.fromEpochMilliseconds(0)
+    val snapshot = TaskSnapshot("task", updated, DownloadState.Queued, segments, now)
+    val client = HttpClient(MockEngine {
+      respond(
+        content = Json.encodeToString(snapshot),
+        headers = headersOf(HttpHeaders.ContentType, "application/json"),
+      )
+    }) {
+      install(Resources)
+      install(ContentNegotiation) { json() }
+    }
+    try {
+      val task = RemoteDownloadTask(
+        taskId = "task",
+        request = original,
+        createdAt = now,
+        initialState = DownloadState.Queued,
+        initialSegments = emptyList(),
+        httpClient = client,
+        onRemoved = {},
+      )
+
+      task.setSpeedLimit(updated.speedLimit)
+
+      assertEquals(updated, task.requestState.value)
+      assertEquals(updated, task.request)
+      assertEquals(segments, task.segments.value)
+
+      val completed = listOf(Segment(0, 0, 99, 100))
+      task.updateState(task.state.value, updated.copy(speedLimit = SpeedLimit.Unlimited), completed)
+      assertEquals(SpeedLimit.Unlimited, task.requestState.value.speedLimit)
+      assertEquals(completed, task.segments.value)
+
+      // Events from older servers omit settings and segments; preserve the latest values.
+      task.updateState(task.state.value)
+      assertEquals(SpeedLimit.Unlimited, task.request.speedLimit)
+      assertEquals(completed, task.segments.value)
+    } finally {
+      client.close()
+    }
+  }
+}

--- a/library/server/src/main/kotlin/com/linroid/ketch/server/api/EventRoutes.kt
+++ b/library/server/src/main/kotlin/com/linroid/ketch/server/api/EventRoutes.kt
@@ -11,7 +11,8 @@ import io.ktor.server.sse.sse
 import io.ktor.sse.ServerSentEvent
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
@@ -20,12 +21,12 @@ private val log = KetchLogger("EventRoutes")
 
 /**
  * Installs the `/api/events` SSE endpoint that streams real-time
- * download state changes to connected clients.
+ * download state, request configuration, and segment changes to connected clients.
  *
  * Events are sent for:
  * - [TaskEvent.TaskAdded]: a new task appears in the tasks list
  * - [TaskEvent.TaskRemoved]: a task is removed from the tasks list
- * - [TaskEvent.StateChanged]: a task's state changes
+ * - [TaskEvent.StateChanged]: state, settings, or segments change while not downloading
  * - [TaskEvent.Progress]: download progress update
  */
 internal fun Route.eventRoutes(ketch: KetchApi) {
@@ -76,12 +77,6 @@ internal fun Route.eventRoutes(ketch: KetchApi) {
       sendEvent(TaskEvent.Error(taskId = taskId))
       return@sse
     }
-    sendEvent(
-      TaskEvent.StateChanged(
-        taskId = task.taskId,
-        state = task.state.value,
-      ),
-    )
     trackTaskState(task)
   }
 }
@@ -89,22 +84,27 @@ internal fun Route.eventRoutes(ketch: KetchApi) {
 private suspend fun ServerSSESession.trackTaskState(
   task: DownloadTask,
 ) {
-  task.state.drop(1)
-    .collect { state ->
-      val event = when (state) {
-        is DownloadState.Downloading -> TaskEvent.Progress(
-          taskId = task.taskId,
-          state = state,
-        )
-
-        else -> TaskEvent.StateChanged(
-          taskId = task.taskId,
-          state = state,
-        )
-      }
-      sendEvent(event)
-    }
+  taskEvents(task).collect { sendEvent(it) }
 }
+
+internal fun taskEvents(task: DownloadTask): Flow<TaskEvent> =
+  combine(task.state, task.requestState, task.segments) { state, request, segments ->
+    when (state) {
+      is DownloadState.Downloading -> TaskEvent.Progress(
+        taskId = task.taskId,
+        state = state,
+        request = request,
+        segments = segments,
+      )
+
+      else -> TaskEvent.StateChanged(
+        taskId = task.taskId,
+        state = state,
+        request = request,
+        segments = segments,
+      )
+    }
+  }
 
 private suspend fun ServerSSESession.sendEvent(event: TaskEvent) {
   log.d { "SSE event: ${event.eventType.value} taskId=${event.taskId}" }

--- a/library/server/src/test/kotlin/com/linroid/ketch/server/TaskEventsTest.kt
+++ b/library/server/src/test/kotlin/com/linroid/ketch/server/TaskEventsTest.kt
@@ -1,0 +1,65 @@
+package com.linroid.ketch.server
+
+import com.linroid.ketch.api.Destination
+import com.linroid.ketch.api.DownloadCondition
+import com.linroid.ketch.api.DownloadPriority
+import com.linroid.ketch.api.DownloadRequest
+import com.linroid.ketch.api.DownloadSchedule
+import com.linroid.ketch.api.DownloadState
+import com.linroid.ketch.api.DownloadTask
+import com.linroid.ketch.api.Segment
+import com.linroid.ketch.api.SpeedLimit
+import com.linroid.ketch.endpoints.model.TaskEvent
+import com.linroid.ketch.server.api.taskEvents
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Instant
+
+class TaskEventsTest {
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  @Test
+  fun settingsAndSegmentsChange_withoutStateChange_emitsUpdatedEvents() = runTest {
+    val task = ObservableTask()
+    val events = mutableListOf<TaskEvent>()
+    backgroundScope.launch { taskEvents(task).collect { events.add(it) } }
+    runCurrent()
+    assertEquals(1, events.size)
+
+    task.requestState.value = task.request.copy(speedLimit = SpeedLimit.of(1024))
+    runCurrent()
+    assertEquals(2, events.size)
+    assertEquals(task.request, assertIs<TaskEvent.StateChanged>(events.last()).request)
+
+    task.segments.value = listOf(Segment(0, 0, 99, 100))
+    runCurrent()
+    assertEquals(3, events.size)
+    val event = assertIs<TaskEvent.StateChanged>(events.last())
+    assertEquals(task.segments.value, event.segments)
+    assertEquals(DownloadState.Queued, event.state)
+  }
+
+  private class ObservableTask : DownloadTask {
+    override val taskId = "task"
+    override val requestState = MutableStateFlow(DownloadRequest("https://example.com/file"))
+    override val request get() = requestState.value
+    override val createdAt = Instant.fromEpochMilliseconds(0)
+    override val state = MutableStateFlow<DownloadState>(DownloadState.Queued)
+    override val segments = MutableStateFlow<List<Segment>>(emptyList())
+    override suspend fun pause() = error("Unexpected call")
+    override suspend fun resume(destination: Destination?) = error("Unexpected call")
+    override suspend fun cancel() = error("Unexpected call")
+    override suspend fun remove(deleteFiles: Boolean) = error("Unexpected call")
+    override suspend fun setSpeedLimit(limit: SpeedLimit) = error("Unexpected call")
+    override suspend fun setPriority(priority: DownloadPriority) = error("Unexpected call")
+    override suspend fun setConnections(connections: Int) = error("Unexpected call")
+    override suspend fun reschedule(
+      schedule: DownloadSchedule,
+      conditions: List<DownloadCondition>,
+    ) = error("Unexpected call")
+  }
+}

--- a/library/server/src/test/kotlin/com/linroid/ketch/server/TestHelpers.kt
+++ b/library/server/src/test/kotlin/com/linroid/ketch/server/TestHelpers.kt
@@ -112,6 +112,7 @@ private class RecordingTask(
 ) : DownloadTask {
   override val taskId: String get() = delegate.taskId
   override val request: DownloadRequest get() = delegate.request
+  override val requestState: StateFlow<DownloadRequest> get() = delegate.requestState
   override val createdAt = delegate.createdAt
   override val state: StateFlow<DownloadState> get() = delegate.state
   override val segments: StateFlow<List<Segment>> get() = delegate.segments


### PR DESCRIPTION
Changing a download's speed limit now updates the card, speed selector, and info panel immediately. Remote tasks also receive live segment and request updates, even when the download state does not change.

- Add observable `DownloadTask.requestState` and keep `request` synchronized with persisted settings and remote snapshots.
- Stream request and segment changes over SSE, preserving existing values when older servers omit the new fields.
- Add regression tests for local request updates, remote responses, and server events.

Validation: passed `:library:core:jvmTest`, `:library:remote:jvmTest`, `:library:server:test`, and `:app:shared:compileKotlinJvm` on latest main. `git diff --check` passed.

Closes #143.
