### PR TITLE
feat(torrent): establish portable engine contracts and platform CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "codex/torrent-*" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,7 +53,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5
 
       - name: Run Android unit tests
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest :library:torrent:testAndroidHostTest :library:core:testAndroidHostTest
 
       - name: Upload test results
         if: always()
@@ -79,7 +79,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v5
 
       - name: Run iOS simulator tests
-        run: ./gradlew iosSimulatorArm64Test
+        run: ./gradlew iosSimulatorArm64Test -PenableIosSimulatorTests=true
 
       - name: Upload test results
         if: always()

--- a/docs/plans/pure-kotlin-torrent-roadmap.md
+++ b/docs/plans/pure-kotlin-torrent-roadmap.md
@@ -1,0 +1,252 @@
+# Pure Kotlin torrent downloader roadmap
+
+Status: **Approved 2026-09-08 — implementation in progress.**
+
+Prepared 2026-09-07; final checkout inspected: `077a0c9d`. This document
+authorizes no implementation by itself. After approval, deliver the agreed scope through the
+stack below. It supersedes the backend choice in the historical
+[BitTorrent assessment](kmp-expert-plan.md), not that document's approval status.
+
+## Proposed outcome and scope
+
+Replace libtorrent4j with a Kotlin Multiplatform BitTorrent v1 engine in `library:torrent`.
+Keep `TorrentDownloadSource()` as the normal entry point. Deliver working downloads on JVM,
+Android, and iOS, including desktop apps, CLI/daemon, and remote clients.
+
+“Pure Kotlin” means torrent parsing, hashing, trackers, DHT, peer protocol, scheduling, storage
+coordination, and resume logic are Kotlin, primarily in `commonMain`. Coroutines, Ktor, Okio,
+Kotlin/Native, and platform socket/filesystem/TLS services remain acceptable dependencies.
+No native torrent engine, JNI torrent bindings, external downloader process, or bundled
+libtorrent binary may remain in the finished product.
+
+| Included in this stack | Completion boundary |
+| --- | --- |
+| BitTorrent v1 | Single-file and multi-file metainfo, SHA-1 verification, TCP peers |
+| Inputs | HTTP/HTTPS `.torrent` URLs, an SDK entry point for metainfo bytes, local `.torrent` files through CLI/app adapters, and `btih` magnets |
+| Trackers | HTTP/HTTPS and UDP announces, compact and dictionary peer lists, tracker tiers and failover |
+| Public peer discovery | DHT bootstrap, lookup and announcement; trackerless magnets; metadata exchange; PEX |
+| Address families | IPv4 and IPv6 peers, trackers, and DHT where the host network supports them |
+| Task behavior | Concurrent torrents, file selection, accurate progress, pause/resume, cancellation, deletion, live speed and connection limits |
+| Upload behavior | Explicit upload policy, upload limits, and optional seeding after completion |
+| Persistence | Versioned Kotlin resume state, verified restart recovery, and recovery of legacy tasks |
+| Platforms | JVM 11+, Android minSdk 26, `iosArm64`, and `iosSimulatorArm64`, subject to the repository's actual toolchain |
+| Browser | Torrent control through `RemoteKetch`; no browser-local TCP/UDP engine |
+
+This is a complete **v1 downloader**, not feature parity with every libtorrent capability.
+Defer v2/hybrid support, uTP, protocol encryption, web seeds, torrent creation, local service
+discovery, NAT port mapping/hole punching, and a torrent-management UI with ratios/queues.
+Reject unsupported v2/hybrid inputs clearly rather than silently implying v2 verification.
+V2 changes metadata, identity, and integrity handling and deserves its own approved stack.
+See [BEP 52](https://www.bittorrent.org/beps/bep_0052.html).
+
+Storage initially targets filesystem paths, including app-owned Android storage and the iOS
+sandbox. Arbitrary Android SAF document trees and iOS security-scoped external folders are
+separate adapters; unsupported destinations must fail before transfer. iOS completion means
+foreground execution plus safe recovery after suspension/relaunch, without promising unrestricted
+background peer-to-peer networking. New standalone Kotlin/Native desktop targets are out of scope.
+
+## Findings from the current implementation
+
+These are code inspection findings; no baseline test run was performed during roadmap design.
+
+- `TorrentEngine` and `TorrentSession` already isolate the backend. Retain that seam and evolve
+  its internal contracts as needed. The iOS factory currently throws `Unsupported`.
+- `TorrentMetadata.fromBencode()` hashes a decode/encode reconstruction and discards the piece
+  hash array. It also flattens tracker tiers and does not retain private-torrent policy.
+- `Bencode` accepts trailing input and lacks the depth, length, and binary-key handling needed
+  for a network-facing engine. `MagnetUri` needs correct UTF-8 percent encoding/decoding.
+- `TorrentDownloadSource.resolveMetadata()` rejects direct `.torrent` URLs; the source does not
+  pass torrent bytes into `addTorrent()` for metainfo-based downloads.
+- One source-wide `activeSession` is used for resume snapshots, despite concurrent task support.
+  Engine startup also lacks synchronization.
+- `Libtorrent4jSession.saveResumeData()` always returns null; `addTorrent()` does not restore
+  its supplied bytes. The replacement must implement actual restart recovery.
+- Progress is distributed proportionally across files. Native status refresh is not called by
+  the source's monitoring loop. Neither behavior is suitable for verified file progress.
+- Torrent payloads bypass `DownloadContext.throttle`; only an initial task limit is applied.
+- The source does not receive the coordinator's resolved output path. Generic zero-byte
+  completion bypasses the source, which cannot correctly create an empty multi-file layout.
+- `Ketch.close()` has no source lifecycle hook. Cleanup currently depends on a live native handle.
+- CLI download/server constructors do not consistently register torrent support.
+- CI filters PRs to `main`, so later PRs based on stack branches would not run that workflow.
+  Torrent simulator tests require `enableIosSimulatorTests=true`, absent from the current job.
+
+Relevant implementation files:
+[source](../../library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentDownloadSource.kt),
+[metadata](../../library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadata.kt),
+[native session](../../library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/Libtorrent4jSession.kt),
+[execution](../../library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadExecution.kt),
+and [CI](../../.github/workflows/tests.yml).
+
+## Architecture and behavior decisions
+
+Keep one torrent module. Internal packages can separate `metainfo`, `wire`, `tracker`, `dht`,
+`peer`, `storage`, and `session`; avoid extra published modules until there is a concrete need.
+
+```mermaid
+flowchart TD
+  K[Ketch task and queue] --> S[TorrentDownloadSource]
+  S --> E[KotlinTorrentEngine]
+  E --> T[Per-task torrent session]
+  E --> D[Shared discovery and socket runtime]
+  D --> R[Trackers and DHT]
+  T --> P[Peer connections and piece scheduler]
+  P --> V[Piece verification and storage]
+  T --> C[Resume checkpoints]
+  P --> B[Ketch bandwidth throttle]
+```
+
+**Portable runtime.** Use a small injectable TCP/UDP transport backed by `ktor-network`, with
+bounded queues and cancellable operations. Reuse the existing `HttpEngine` abstraction for
+bounded metainfo/tracker HTTP requests, with a Ktor default and explicit resource ownership.
+Reuse the existing Ktor platform HTTP engines for HTTPS, including Darwin on iOS. Add only the
+filesystem/randomness/clock adapters that common code needs. Prove actual iOS TCP, UDP, and file
+operations early; common-source compilation alone is insufficient. Ktor documents its
+[socket API](https://ktor.io/docs/server-sockets.html) and
+[platform HTTP engines](https://ktor.io/docs/client-engines.html).
+
+**Metadata identity.** Preserve exact encoded `info` bytes and piece hashes; validate before
+allocation or file creation. Use byte-preserving bencode keys and separate full-document parsing
+from prefix parsing needed by metadata messages. Implement incremental SHA-1 in common Kotlin
+with known-answer tests; use common Base64 utilities. Keep metainfo in an internal bounded cache
+and durable checkpoint rather than embedding large payloads in public `ResolvedSource`/SSE data.
+The protocol's identity and piece rules come from
+[BEP 3](https://www.bittorrent.org/beps/bep_0003.html).
+
+**Ownership and concurrency.** A source owns one lazily initialized runtime. Each task owns its
+session, coroutine scope, selected-file mapping, disk manifest, and checkpoint. Serialize mutable
+session state and route updates by task ID. Initially allow one active owner per info hash per
+runtime; reject a second active task for that hash explicitly instead of sharing a mutable handle
+across destinations. Distinct torrents run concurrently. Duplicate metadata requests may share
+work without one caller's cancellation canceling the others.
+
+**Storage and integrity.** Map logical torrent offsets to individual files using checked `Long`
+arithmetic. Download whole boundary pieces when selection cuts across files; retain necessary
+unselected bytes in task-owned sidecar storage. Count only verified, committed selected bytes as
+task progress. Track network bytes separately for speed, upload accounting, and tracker counters.
+Never announce an unverified piece or report selected completion before required writes finish.
+Partial selection does not imply whole-swarm completion or a tracker `completed` event.
+
+Reject traversal, absolute paths, unsafe path components, file/directory collisions, and
+platform-normalization collisions. Prevent symlink escapes through platform storage adapters;
+do not rely solely on string prefix checks. Cleanup uses a validated ownership manifest and must
+work after restart without a live session. It must preserve pre-existing and unrelated files.
+Enforce limits on metadata, files, pieces, buffers, open handles, peer lists, and queued work.
+
+**Bandwidth and lifecycle.** Admit bounded payload blocks through `DownloadContext.throttle`
+and couple receive/request backpressure to it so global and task limits apply together. Account
+for duplicate/corrupt payload too; never hold the session lock while waiting for tokens or I/O.
+Map live connection settings to peer limits, independently of virtual file segments. Add a
+default source-close hook and connect it to Ketch shutdown. Pause/cancel must stop discovery and
+requests for that task, flush a consistent snapshot, and release resources in cancellation-safe
+cleanup. Seeding ends on source shutdown or task removal and does not retain a download queue slot.
+
+**Upload policy.** Replace the ambiguous `enableUpload` behavior with an explicit policy:
+`Disabled` (default), `WhileDownloading`, or `SeedAfterCompletion`. Preserve a deprecated boolean
+mapping if needed. Apply upload rate and connection limits; serve only verified available pieces.
+Document that disabling uploads can reduce swarm performance. Completion remains a completed
+Ketch download even while an explicitly enabled seed session continues in the source runtime.
+
+**Discovery and privacy.** Preserve tracker tiers and authenticate UDP replies by endpoint,
+transaction, and action. Retain peer provenance. Private metainfo permits tracker-only discovery;
+switching private trackers drops peers from the previous tracker, following
+[BEP 27](https://www.bittorrent.org/beps/bep_0027.html).
+Private downloads require metainfo input; an unresolved magnet cannot prove its privacy status.
+If magnet metadata reveals `private=1`, stop public discovery/connections and require metainfo
+instead of claiming that the earlier lookup was private. Do not log tracker passkeys or headers.
+
+**Recovery.** A versioned checkpoint stores verified metainfo, file selection, output mapping,
+piece state, and owned sidecar information. Flush data before publishing a checkpoint through
+`TaskStore`; validate identity and rehash local pieces on restart before trusting them. Missing,
+truncated, changed, or corrupt pieces become downloadable again. Legacy native blobs are never
+interpreted as Kotlin state: recover metadata from the original input and recheck existing files.
+If metadata cannot be recovered, fail with a useful error while preserving downloaded files.
+
+## Proposed stacked PRs
+
+Each row is a review boundary, with implementation and meaningful tests together. A row may be
+split if its diff becomes too large, without changing the approved outcome. Dependencies remain
+linear for review even where underlying components are independent.
+
+| PR | Deliverable | Required evidence before moving on |
+| --- | --- | --- |
+| 01 — Contracts and CI | Establish task/session ownership, configuration and upload policy, output-path/source-lifecycle contracts, deterministic clock/transport fixtures. Enable CI for stack bases and actual torrent simulator execution; confirm AGP test task names. Keep the native default during construction. | Existing affected tests pass; concurrent source lifecycle tests; CI selects and executes torrent tests instead of silently skipping them. |
+| 02 — Metainfo and hashing | Harden bencode, raw info hashing, piece arrays, tracker tiers, private flag, magnet parsing, input limits, common SHA-1/Base64. | Independent hash fixtures; malformed/oversized inputs; UTF-8; negative lengths, overflow, zero-length files, and unsupported versions. |
+| 03 — Portable I/O | TCP/UDP transports, bounded HTTP fetch adapter, storage read/write/flush primitives, owned runtime resources, platform cancellation. | Real loopback TCP/UDP, HTTPS fetch fixture, random-access files and close/cancel checks on JVM/Android/iOS. |
+| 04 — Peer wire protocol | Handshake, frame codec, bitfield/have, choke/interest, request/piece/cancel, keepalive, protocol state validation and deadlines. | Fragmented/coalesced frames, short final blocks, bad hashes/indices/lengths, unsolicited blocks, disconnects, and bounded allocations. |
+| 05 — Verified storage | Multi-file offset mapping, piece assembly/hash checking, sidecars for selected boundary pieces, destination validation, owned-file cleanup. | Real cross-file writes, subset selection, empty layouts, disk failures, path/symlink attacks, and no progress from corrupt pieces. |
+| 06 — First Kotlin transfer | `KotlinTorrentEngine`/session connects an explicitly supplied peer to verified storage; internal test selection of the backend; observable states and errors. | Complete single-file and multi-file downloads from a local independent seeder; exact output checksums; cancellation and cleanup. |
+| 07 — Trackers | HTTP/HTTPS and UDP announces, binary query escaping, dictionary/compact peers, IPv6, tier failover, intervals, events, backoff and response correlation. | Local tracker fixtures; retries/spoofed UDP replies; private tracker switching; accurate whole-torrent `left` and partial-selection event handling. |
+| 08 — Swarm scheduling and upload | Multiple peers, availability tracking, rarest-first selection, bounded request pipelines, retry/reassignment, endgame cancellation, bad-peer handling, upload/choking and optional seeding. | A swarm with complementary pieces, slow/disconnecting/corrupt peers and duplicates completes; upload policy/limits hold; no unbounded work or stalled final piece. |
+| 09 — Magnet metadata | Extension negotiation, per-peer extension IDs, metadata request/data/reject, bounded assembly, hash validation, metadata cache and handoff to download. | Tracker-backed magnets work against an independent client; mismatched/oversized metadata and timeout/cancellation are handled; no duplicate metadata fetch during handoff. |
+| 10 — DHT foundations | KRPC codec, endpoint/transaction validation, node identity, routing buckets, token issuance/validation, bounded tables and persistence format. | Deterministic routing/token/expiry cases, malformed datagrams and response-size/rate bounds; IPv4/IPv6 address encoding. |
+| 11 — Trackerless discovery and PEX | DHT bootstrap/lookup/announce/refresh, saved-node recovery, IPv6 DHT and node-ID hardening, peer exchange, discovery policy and quotas. | Trackerless magnet download through a controlled DHT plus independent peer; cold/warm startup; PEX added/dropped limits; private torrents never use public discovery. |
+| 12 — Durable resume | Checkpoint ordering, restart rehash, metadata persistence, pause/resume, selection restoration, legacy task recovery, offline cleanup. | Kill/restart during write and checkpoint; corrupt/missing files; non-contiguous selected IDs; pause one of two torrents; delete after restart without touching unrelated files. |
+| 13 — Ketch and product integration | Finish metainfo URL/bytes/file adapters, per-task source state, resolved paths, empty layouts, verified progress, live throttle/connections, source shutdown, CLI/daemon and app registration. Switch default factories on JVM/Android/iOS. | Public API and app/CLI flows complete real downloads; mixed HTTP+torrent global limit test; remote resolve/select/progress/resume; repeated start/close releases ports and files. |
+| 14 — Interoperability and native removal | Expand independent-client matrix, hostile-input and churn tests, resource/performance checks, packaging smoke tests, migration/support docs. Remove libtorrent adapters, binaries, loader, catalog entries and keep rules. | All acceptance gates below pass; final Gradle dependency graphs and packaged artifacts contain no torrent JNI/native dependency. |
+
+Tracker implementation references:
+[BEP 12](https://www.bittorrent.org/beps/bep_0012.html),
+[BEP 15](https://www.bittorrent.org/beps/bep_0015.html),
+[BEP 23](https://www.bittorrent.org/beps/bep_0023.html), and
+[BEP 7](https://www.bittorrent.org/beps/bep_0007.html).
+Metadata exchange follows
+[BEP 10](https://www.bittorrent.org/beps/bep_0010.html) and
+[BEP 9](https://www.bittorrent.org/beps/bep_0009.html).
+Discovery follows
+[BEP 5](https://www.bittorrent.org/beps/bep_0005.html),
+[BEP 32](https://www.bittorrent.org/beps/bep_0032.html),
+[BEP 42](https://www.bittorrent.org/beps/bep_0042.html), and
+[BEP 11](https://www.bittorrent.org/beps/bep_0011.html).
+
+## Validation and definition of done
+
+Follow the repository's [testing rules](../development/testing.md): `kotlin.test`, hand-written
+fakes, coroutine virtual time, and behavior tests in `commonTest` unless platform-specific.
+Do not make public internet swarms or trackers a CI dependency. Use generated redistributable
+payloads, local trackers/DHT fixtures, and pinned independent client processes only in tests.
+
+The stack is complete only when all of the following have evidence:
+
+1. `.torrent` URLs, metainfo bytes/local files, tracker-backed magnets, and trackerless magnets
+   complete with exact checksums. Include two independently implemented clients, such as
+   Transmission and a libtorrent-based client, pinned when the test harness is implemented.
+2. Multi-file selection, boundary pieces, zero-byte files, and files larger than 2 GiB work with
+   bounded memory. Unsupported inputs and destinations produce clear errors before writes.
+3. Pausing, restarting the process, losing connectivity, corrupting a piece, and canceling during
+   I/O do not cause false completion, cross-task state, leaked resources, or unrelated deletion.
+4. Task/global download limits work across simultaneous HTTP and torrent downloads, including
+   live changes. Upload policy and limits work separately. Verified progress and received-byte
+   speed are distinguishable so hash checking/retries do not produce misleading task state.
+5. Parser, tracker, DHT and peer abuse fixtures demonstrate configured bounds on memory,
+   sockets, pending requests, caches and retries. Private-tracker policy is tested end to end.
+6. JVM tests, Android host and device/emulator smoke tests, and enabled iOS simulator tests pass.
+   A foreground iOS transfer is exercised; physical-device checks are recorded separately if
+   hardware is available. Desktop and CLI packages start without native torrent binaries;
+   smoke-test GraalVM output where the CLI build uses it.
+7. Compare throughput, peak memory and file-handle counts against the native baseline using the
+   same local swarm and payload. Record measurements at PR 06 and PR 14. Fix unexplained stalls
+   and resource growth; do not claim performance parity without measurements or invent a target
+   before establishing the baseline.
+8. Existing HTTP/FTP, task persistence and remote API regression checks pass. Documentation
+   describes the protocol/platform matrix, upload defaults, recovery behavior and limitations.
+
+## Stack execution after approval
+
+- Reinspect the working tree and remote base. Use an isolated checkout/worktree so unrelated
+  work is not included in this feature stack; do not stash or reset the user's work.
+- Use branches such as `codex/torrent-01-contracts`, each subsequent branch based on its
+  predecessor. PR 01 targets `main`; PR 02 targets PR 01's branch, and so on.
+- Open draft PRs once each change and its focused validation are reviewable. Each description
+  explains behavior, validation, remaining limitations and links to its predecessor/successor.
+- Keep every branch buildable and run the affected checks before continuing. Preserve the
+  working native default until PR 13; remove it only after replacement acceptance.
+- Maintain the roadmap checklist and stack links as work progresses. Address failures and
+  integration conflicts before declaring completion; do not stop at the first working download.
+- Approval of this roadmap authorizes implementation and creation/pushing of the PR stack.
+  Merging PRs and publishing releases remain separate actions unless explicitly authorized.
+- Adjust internal boundaries autonomously. Bring back material scope changes, especially
+  dropping an included capability or changing the meaning of pure Kotlin or platform support.
+
+**Approved scope:** this 14-PR BitTorrent v1 implementation, including iOS, DHT/PEX,
+durable resume, optional seeding, and final removal of libtorrent4j, with the stated exclusions.

--- a/library/api/src/androidMain/kotlin/com/linroid/ketch/api/Destination.android.kt
+++ b/library/api/src/androidMain/kotlin/com/linroid/ketch/api/Destination.android.kt
@@ -9,6 +9,7 @@ actual fun Destination.isFile(): Boolean =
   !isName() && !isDirectory()
 
 actual fun Destination.isDirectory(): Boolean {
+  if (':' !in value) return value.endsWith('/') || value.endsWith('\\')
   val uri = Uri.parse(value)
   if (uri.scheme == "content") {
     return DocumentsContract.isTreeUri(uri)
@@ -17,6 +18,7 @@ actual fun Destination.isDirectory(): Boolean {
 }
 
 actual fun Destination.isName(): Boolean {
+  if (':' !in value) return '/' !in value && '\\' !in value
   val uri = Uri.parse(value)
   if (uri.scheme != null) return false
   return !value.contains('/') && !value.contains('\\')

--- a/library/core/build.gradle.kts
+++ b/library/core/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
   }
 
   android {
+    withHostTest {}
     namespace = "com.linroid.ketch.core"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()

--- a/library/core/src/androidMain/kotlin/com/linroid/ketch/core/file/createFileAccessor.android.kt
+++ b/library/core/src/androidMain/kotlin/com/linroid/ketch/core/file/createFileAccessor.android.kt
@@ -18,6 +18,8 @@ actual fun createFileAccessor(
   path: String,
   ioDispatcher: CoroutineDispatcher,
 ): FileAccessor {
+  // A URI scheme requires a colon. Keep ordinary paths independent of Android APIs.
+  if (':' !in path) return PathFileAccessor(path, ioDispatcher)
   val uri = Uri.parse(path)
   return if (uri.isRelative) {
     PathFileAccessor(path, ioDispatcher)

--- a/library/core/src/androidMain/kotlin/com/linroid/ketch/core/file/resolveChildPath.android.kt
+++ b/library/core/src/androidMain/kotlin/com/linroid/ketch/core/file/resolveChildPath.android.kt
@@ -11,6 +11,7 @@ internal actual fun resolveChildPath(
   directory: String,
   fileName: String,
 ): String {
+  if (':' !in directory) return (directory.toPath() / fileName).toString()
   val uri = Uri.parse(directory)
   if (uri.scheme == "content") {
     val parentDocUri = if (DocumentsContract.isTreeUri(uri)) {

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/Ketch.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/Ketch.kt
@@ -425,9 +425,10 @@ class Ketch(
 
   override fun close() {
     log.i { "Closing Ketch" }
-    httpEngine.close()
     coordinator.close()
     scope.cancel()
+    sourceResolver.close()
+    httpEngine.close()
     dispatchers.close()
   }
 }

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadContext.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadContext.kt
@@ -47,4 +47,6 @@ class DownloadContext(
   val preResolved: ResolvedSource? = null,
   val maxConnections: MutableStateFlow<Int> = MutableStateFlow(0),
   var pendingResegment: Int = 0,
+  /** Final destination resolved by Ketch, including default directory and deduplication. */
+  val outputPath: String? = null,
 )

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadCoordinator.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadCoordinator.kt
@@ -281,6 +281,7 @@ internal class DownloadCoordinator(
       onProgress = { _, _ -> },
       throttle = { _ -> },
       headers = handle.request.headers,
+      outputPath = outputPath,
     )
     try {
       source.cleanup(ctx, record.sourceResumeState)

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadExecution.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadExecution.kt
@@ -170,7 +170,7 @@ internal class DownloadExecution(
 
     taskLimiter.delegate = createLimiter(request.speedLimit)
 
-    val preResolved = if (resolved != null) resolvedUrl else null
+    val preResolved = resolvedUrl
     runDownload(outputPath, total, source, preResolved) { ctx ->
       source.download(ctx)
     }
@@ -236,7 +236,7 @@ internal class DownloadExecution(
 
     var completed = false
     try {
-      val ctx = buildContext(fa, total, preResolved)
+      val ctx = buildContext(fa, total, preResolved, outputPath)
       context = ctx
 
       coroutineScope {
@@ -429,6 +429,7 @@ internal class DownloadExecution(
     fileAccessor: FileAccessor,
     totalBytes: Long,
     preResolved: ResolvedSource? = null,
+    outputPath: String,
   ): DownloadContext {
     var lastBytes = 0L
     var lastMark = TimeSource.Monotonic.markNow()
@@ -458,6 +459,7 @@ internal class DownloadExecution(
       },
       headers = request.headers,
       preResolved = preResolved,
+      outputPath = outputPath,
       maxConnections = MutableStateFlow(
         request.connections.takeIf { it > 0 } ?: 0,
       ),

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadSource.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadSource.kt
@@ -14,6 +14,13 @@ import kotlinx.coroutines.CancellationException
  * download requests to the appropriate source based on URL matching.
  */
 interface DownloadSource {
+  /**
+   * Releases resources owned by this source. Called when Ketch closes.
+   * Implementations must be idempotent and stop accepting new work.
+   * Injected resources owned by the caller must not be closed here.
+   */
+  fun close() {}
+
   /** Unique identifier for this source type (e.g., "http", "torrent"). */
   val type: String
 

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/SourceResolver.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/SourceResolver.kt
@@ -2,6 +2,8 @@ package com.linroid.ketch.core.engine
 
 import com.linroid.ketch.api.KetchError
 import com.linroid.ketch.api.log.KetchLogger
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Routes download URLs to the appropriate [DownloadSource].
@@ -11,8 +13,24 @@ import com.linroid.ketch.api.log.KetchLogger
  * Typically [HttpDownloadSource] is registered last as a catch-all
  * fallback.
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class SourceResolver(private val sources: List<DownloadSource>) {
   private val log = KetchLogger("SourceResolver")
+  private val closed = AtomicBoolean(false)
+
+  fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    val uniqueSources = mutableListOf<DownloadSource>()
+    for (source in sources) {
+      if (uniqueSources.any { it === source }) continue
+      uniqueSources.add(source)
+      try {
+        source.close()
+      } catch (e: Exception) {
+        log.w(e) { "Failed to close source '${source.type}'" }
+      }
+    }
+  }
 
   init {
     log.d {
@@ -22,6 +40,7 @@ internal class SourceResolver(private val sources: List<DownloadSource>) {
   }
 
   fun resolve(url: String): DownloadSource {
+    check(!closed.load()) { "Download sources are closed" }
     val source = sources.firstOrNull { it.canHandle(url) }
     if (source != null) {
       log.d { "Resolved source '${source.type}' for URL: $url" }
@@ -32,6 +51,7 @@ internal class SourceResolver(private val sources: List<DownloadSource>) {
   }
 
   fun resolveByType(type: String): DownloadSource {
+    check(!closed.load()) { "Download sources are closed" }
     val source = sources.firstOrNull { it.type == type }
     if (source != null) return source
     log.e { "No source found for type: $type" }

--- a/library/core/src/commonTest/kotlin/com/linroid/ketch/engine/DownloadCoordinatorCleanupTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/ketch/engine/DownloadCoordinatorCleanupTest.kt
@@ -33,6 +33,7 @@ class DownloadCoordinatorCleanupTest {
     override val type: String = "rec",
     override val managesOwnFileIo: Boolean = false,
   ) : DownloadSource {
+    var lastOutputPath: String? = null
     var cleanupCalls = 0
     var lastResumeState: SourceResumeState? = null
     var lastFileAccessorType: String? = null
@@ -55,6 +56,7 @@ class DownloadCoordinatorCleanupTest {
       context: DownloadContext,
       resumeState: SourceResumeState?,
     ) {
+      lastOutputPath = context.outputPath
       cleanupCalls++
       lastResumeState = resumeState
       lastFileAccessorType =
@@ -121,6 +123,7 @@ class DownloadCoordinatorCleanupTest {
 
     assertEquals(1, source.cleanupCalls)
     assertEquals(resume, source.lastResumeState)
+    assertEquals("/tmp/file.zip", source.lastOutputPath)
   }
 
   @Test

--- a/library/core/src/commonTest/kotlin/com/linroid/ketch/engine/SourceResolverTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/ketch/engine/SourceResolverTest.kt
@@ -46,6 +46,33 @@ class SourceResolverTest {
   }
 
   @Test
+  fun close_duplicateInstance_closedOnceAndCannotResolve() {
+    var closeCount = 0
+    val source = object : DownloadSource by fakeSource {
+      override fun close() { closeCount++ }
+    }
+    val resolver = SourceResolver(listOf(source, source))
+    resolver.close()
+    resolver.close()
+    assertEquals(1, closeCount)
+    assertFailsWith<IllegalStateException> { resolver.resolve("magnet:test") }
+    assertFailsWith<IllegalStateException> { resolver.resolveByType("magnet") }
+  }
+
+  @Test
+  fun close_failingSource_otherSourcesStillClose() {
+    var closed = false
+    val failing = object : DownloadSource by fakeSource {
+      override fun close() { error("close failed") }
+    }
+    val succeeding = object : DownloadSource by fakeSource {
+      override fun close() { closed = true }
+    }
+    SourceResolver(listOf(failing, succeeding)).close()
+    assertTrue(closed)
+  }
+
+  @Test
   fun resolve_httpUrl_returnsHttpSource() {
     val resolver = SourceResolver(listOf(httpSource))
     val source = resolver.resolve("https://example.com/file.zip")

--- a/library/torrent/build.gradle.kts
+++ b/library/torrent/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
 
 kotlin {
   android {
+    withHostTest {}
     namespace = "com.linroid.ketch.torrent"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConfig.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConfig.kt
@@ -22,7 +22,31 @@ data class TorrentConfig(
   val connectionsPerTorrent: Int = 100,
   val enableUpload: Boolean = false,
   val listenPort: Int = 0,
+  /** Explicit policy; null preserves the legacy [enableUpload] setting. */
+  val uploadPolicy: TorrentUploadPolicy? = null,
+  /** Maximum metainfo bytes accepted from HTTP or peers. */
+  val maxMetadataBytes: Int = 4 * 1024 * 1024,
+  /** Maximum simultaneously buffered piece data across the engine. */
+  val maxBufferedBytes: Int = 32 * 1024 * 1024,
+
 ) {
+  init {
+    require(maxActiveTorrents > 0) { "maxActiveTorrents must be positive" }
+    require(connectionsPerTorrent > 0) { "connectionsPerTorrent must be positive" }
+    require(metadataTimeoutSeconds >= 0) { "metadata timeout must be non-negative" }
+    require(listenPort in 0..65535) { "listenPort must be in 0..65535" }
+    require(maxMetadataBytes > 0) { "maxMetadataBytes must be positive" }
+    require(maxBufferedBytes >= 16384) { "maxBufferedBytes must hold a protocol block" }
+  }
+
+  /** Effective policy, including compatibility with the legacy boolean. */
+  val effectiveUploadPolicy: TorrentUploadPolicy
+    get() = uploadPolicy ?: if (enableUpload) {
+      TorrentUploadPolicy.SEED_AFTER_COMPLETION
+    } else {
+      TorrentUploadPolicy.DISABLED
+    }
+
   /** Metadata fetch timeout as a [Duration]. */
   val metadataTimeout: Duration
     get() = metadataTimeoutSeconds.seconds

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSessionRegistry.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSessionRegistry.kt
@@ -1,0 +1,36 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** Reserves swarm ownership before starting I/O and routes snapshots by task identity. */
+internal class TorrentSessionRegistry {
+  private data class Entry(val infoHash: String, var session: TorrentSession? = null)
+
+  private val mutex = Mutex()
+  private val entries = mutableMapOf<String, Entry>()
+
+  suspend fun reserve(taskId: String, infoHash: String) = mutex.withLock {
+    check(taskId !in entries) { "Torrent task is already active: $taskId" }
+    check(entries.values.none { it.infoHash == infoHash }) {
+      "Torrent already has an active owner: $infoHash"
+    }
+    entries[taskId] = Entry(infoHash)
+  }
+
+  suspend fun attach(taskId: String, session: TorrentSession) = mutex.withLock {
+    val entry = checkNotNull(entries[taskId]) { "Torrent task has no reservation" }
+    check(entry.infoHash == session.infoHash) { "Torrent session identity mismatch" }
+    check(entry.session == null) { "Torrent task already has a session" }
+    entry.session = session
+  }
+
+  suspend fun session(taskId: String): TorrentSession? = mutex.withLock {
+    entries[taskId]?.session
+  }
+
+  suspend fun release(taskId: String) = mutex.withLock {
+    entries.remove(taskId)
+    Unit
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentUploadPolicy.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentUploadPolicy.kt
@@ -1,0 +1,13 @@
+package com.linroid.ketch.torrent
+
+/** Controls whether verified torrent pieces may be uploaded to peers. */
+enum class TorrentUploadPolicy {
+  /** Never upload file payload. */
+  DISABLED,
+
+  /** Upload while selected files are downloading, then stop. */
+  WHILE_DOWNLOADING,
+
+  /** Continue uploading after selected files finish, until removed or closed. */
+  SEED_AFTER_COMPLETION,
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPolicyTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPolicyTest.kt
@@ -1,0 +1,31 @@
+package com.linroid.ketch.torrent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TorrentPolicyTest {
+  @Test
+  fun uploadPolicy_explicitPolicyOverridesLegacyFlag() {
+    val config = TorrentConfig(enableUpload = true, uploadPolicy = TorrentUploadPolicy.DISABLED)
+    assertEquals(TorrentUploadPolicy.DISABLED, config.effectiveUploadPolicy)
+    assertEquals(
+      TorrentUploadPolicy.SEED_AFTER_COMPLETION,
+      TorrentConfig(enableUpload = true).effectiveUploadPolicy
+    )
+    assertEquals(
+      TorrentUploadPolicy.DISABLED,
+      config.copy(uploadPolicy = null, enableUpload = false).effectiveUploadPolicy
+    )
+  }
+
+  @Test
+  fun config_invalidResourceLimitsRejected() {
+    assertFailsWith<IllegalArgumentException> { TorrentConfig(maxActiveTorrents = 0) }
+    assertFailsWith<IllegalArgumentException> { TorrentConfig(connectionsPerTorrent = 0) }
+    assertFailsWith<IllegalArgumentException> { TorrentConfig(listenPort = 65536) }
+    assertFailsWith<IllegalArgumentException> { TorrentConfig(maxMetadataBytes = 0) }
+    assertFailsWith<IllegalArgumentException> { TorrentConfig(maxBufferedBytes = 16383) }
+    assertFailsWith<IllegalArgumentException> { TorrentConfig(metadataTimeoutSeconds = -1) }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSessionRegistryTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSessionRegistryTest.kt
@@ -1,0 +1,47 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class TorrentSessionRegistryTest {
+  @Test
+  fun reserve_concurrentSameSwarm_onlyOneOwner() = runTest {
+    val registry = TorrentSessionRegistry()
+    val results = (0..10).map { id ->
+      async { runCatching { registry.reserve("task-$id", "hash") }.isSuccess }
+    }.awaitAll()
+    assertEquals(1, results.count { it })
+  }
+
+  @Test
+  fun release_oneTask_doesNotRemoveOtherSession() = runTest {
+    val registry = TorrentSessionRegistry()
+    val first = FakeTorrentSession("first")
+    val second = FakeTorrentSession("second")
+    registry.reserve("a", first.infoHash)
+    registry.reserve("b", second.infoHash)
+    registry.attach("a", first)
+    registry.attach("b", second)
+    assertSame(first, registry.session("a"))
+    registry.release("a")
+    assertNull(registry.session("a"))
+    assertSame(second, registry.session("b"))
+    registry.reserve("c", first.infoHash)
+  }
+
+  @Test
+  fun attach_wrongSwarm_rejectedWithoutReplacingOwner() = runTest {
+    val registry = TorrentSessionRegistry()
+    registry.reserve("a", "first")
+    assertFailsWith<IllegalStateException> {
+      registry.attach("a", FakeTorrentSession("second"))
+    }
+    assertNull(registry.session("a"))
+  }
+}

--- a/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/Libtorrent4jEngine.kt
+++ b/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/Libtorrent4jEngine.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import org.libtorrent4j.Address
 import org.libtorrent4j.AlertListener
 import org.libtorrent4j.Priority
 import org.libtorrent4j.SessionHandle
@@ -15,6 +16,7 @@ import org.libtorrent4j.TorrentInfo
 import org.libtorrent4j.alerts.Alert
 import org.libtorrent4j.alerts.AlertType
 import org.libtorrent4j.alerts.MetadataReceivedAlert
+import org.libtorrent4j.swig.ip_filter
 import org.libtorrent4j.swig.settings_pack
 import java.io.File
 import kotlin.coroutines.resume
@@ -77,6 +79,16 @@ internal class Libtorrent4jEngine(
     val params = SessionParams(settings)
     val mgr = SessionManager()
     mgr.start(params)
+    if (config.effectiveUploadPolicy == TorrentUploadPolicy.DISABLED) {
+      // The default local peer class bypasses choke slots. Keep only the global class
+      // for every address so LAN peers obey both the zero slots and global rate limits.
+      val classes = ip_filter()
+      classes.add_rule(Address.parseIp("0.0.0.0").swig(),
+        Address.parseIp("255.255.255.255").swig(), 1)
+      classes.add_rule(Address.parseIp("::").swig(),
+        Address.parseIp("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").swig(), 1)
+      mgr.swig().set_peer_class_filter(classes)
+    }
     session = mgr
     log.i { "Torrent engine started" }
   }

--- a/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/Libtorrent4jEngine.kt
+++ b/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/Libtorrent4jEngine.kt
@@ -55,8 +55,18 @@ internal class Libtorrent4jEngine(
     )
     settings.setInteger(
       settings_pack.int_types.active_seeds.swigValue(),
-      if (config.enableUpload) config.maxActiveTorrents else 0,
+      if (config.effectiveUploadPolicy == TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
+        config.maxActiveTorrents
+      } else {
+        0
+      },
     )
+    if (config.effectiveUploadPolicy == TorrentUploadPolicy.DISABLED) {
+      // A fixed zero slot count keeps all peers choked, including optimistic unchokes.
+      settings.setInteger(settings_pack.int_types.choking_algorithm.swigValue(), 0)
+      settings.setInteger(settings_pack.int_types.unchoke_slots_limit.swigValue(), 0)
+      settings.setInteger(settings_pack.int_types.num_optimistic_unchoke_slots.swigValue(), 0)
+    }
     if (config.listenPort > 0) {
       settings.setString(
         settings_pack.string_types.listen_interfaces.swigValue(),
@@ -65,7 +75,7 @@ internal class Libtorrent4jEngine(
     }
 
     val params = SessionParams(settings)
-    val mgr = SessionManager(config.enableUpload)
+    val mgr = SessionManager()
     mgr.start(params)
     session = mgr
     log.i { "Torrent engine started" }


### PR DESCRIPTION
Begins the approved pure Kotlin BitTorrent v1 replacement stack. Self-managed download sources now receive Ketch's resolved destination and a source shutdown hook; resolution results are reused when starting a download. A task/session registry enforces exclusive swarm ownership and keeps task lookups separate. Adds validated resource limits and an explicit upload-policy contract for the replacement engine.

Enables Android host tests for core/torrent, opts CI into iOS simulator tests, and runs CI for PRs targeting torrent stack branches. Enabling Android tests exposed unnecessary framework URI parsing for ordinary paths; these now follow the filesystem path directly.

Validation: core and torrent JVM tests, both Android host suites, and torrent iOS simulator tests passed with `-PenableIosSimulatorTests=true`. Includes lifecycle, destination propagation, ownership, and config validation tests. Existing native backend remains the default; Kotlin transfer implementation follows in the stack.

Stack: 01/14. Base: main. Roadmap: docs/plans/pure-kotlin-torrent-roadmap.md. Next: metainfo and common Kotlin hashing.
