### PR TITLE
feat(torrent): add portable network and storage adapters

### DIFF
--- a/library/torrent/build.gradle.kts
+++ b/library/torrent/build.gradle.kts
@@ -45,6 +45,8 @@ kotlin {
     commonMain.dependencies {
       api(projects.library.core)
       implementation(libs.okio)
+      implementation(libs.ktor.network)
+      implementation(projects.library.ktor)
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.kotlinx.serialization.json)
     }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConnect.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConnect.kt
@@ -1,0 +1,26 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.IOException
+
+/** Try every DNS answer, reserving time for later address families within one deadline. */
+internal suspend fun <T, R : Any> connectTorrentCandidates(
+  candidates: List<T>,
+  connect: suspend (T) -> R,
+): R = withTimeout(10_000) {
+  require(candidates.isNotEmpty()) { "No torrent endpoint addresses" }
+  var failure: Exception? = null
+  for (candidate in candidates) {
+    try {
+      val result = withTimeoutOrNull(10_000L / candidates.size) { connect(candidate) }
+      if (result != null) return@withTimeout result
+    } catch (error: Exception) {
+      currentCoroutineContext().ensureActive()
+      failure = error
+    }
+  }
+  throw IOException("Cannot connect to any torrent endpoint address", failure)
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentFileIo.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentFileIo.kt
@@ -1,0 +1,67 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import okio.FileHandle
+import okio.FileSystem
+import okio.Path
+
+internal expect val torrentFileSystem: FileSystem
+internal expect fun torrentRandomBytes(size: Int): ByteArray
+
+/** Serializes file operations and close; callers own directories and destination validation. */
+internal class TorrentFileIo(private val handle: FileHandle) {
+  private val mutex = Mutex()
+  private var closed = false
+
+  suspend fun read(offset: Long, size: Int): ByteArray = operation {
+    require(offset >= 0 && size in 0..16 * 1024 * 1024 && offset <= Long.MAX_VALUE - size)
+    val bytes = ByteArray(size)
+    var count = 0
+    while (count < size) {
+      val received = handle.read(offset + count, bytes, count, size - count)
+      check(received > 0) { "Truncated torrent file" }
+      count += received
+    }
+    bytes
+  }
+
+  suspend fun write(offset: Long, bytes: ByteArray) = operation {
+    require(offset >= 0 && offset <= Long.MAX_VALUE - bytes.size)
+    handle.write(offset, bytes, 0, bytes.size)
+  }
+
+  suspend fun size(): Long = operation { handle.size() }
+  suspend fun flush() = operation { handle.flush() }
+
+  suspend fun close() = withContext(NonCancellable + Dispatchers.IO) {
+    mutex.withLock {
+      if (!closed) {
+        closed = true
+        handle.close()
+      }
+    }
+  }
+
+  private suspend fun <T> operation(block: () -> T): T = mutex.withLock {
+    check(!closed) { "Torrent file is closed" }
+    withContext(Dispatchers.IO) { block() }
+  }
+
+  companion object {
+    suspend fun open(path: Path, fileSystem: FileSystem = torrentFileSystem): TorrentFileIo {
+      var handle: FileHandle? = null
+      try {
+        withContext(Dispatchers.IO) { handle = fileSystem.openReadWrite(path) }
+        return TorrentFileIo(checkNotNull(handle))
+      } catch (e: Throwable) {
+        handle?.close()
+        throw e
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentHttp.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentHttp.kt
@@ -1,0 +1,38 @@
+package com.linroid.ketch.torrent
+
+import com.linroid.ketch.core.engine.HttpEngine
+import com.linroid.ketch.engine.KtorHttpEngine
+import kotlinx.coroutines.withTimeout
+import okio.Buffer
+
+/** Size- and time-bounded HTTP adapter; injected engines remain owned by their caller. */
+internal class TorrentHttp(
+  private val engine: HttpEngine,
+  private val ownsEngine: Boolean = false,
+) {
+  suspend fun fetch(
+    url: String,
+    maxBytes: Int,
+    timeoutMs: Long = 30_000,
+    headers: Map<String, String> = emptyMap(),
+  ): ByteArray = withTimeout(timeoutMs) {
+    require(maxBytes > 0)
+    require(url.startsWith("https://", true) || url.startsWith("http://", true))
+    val output = Buffer()
+    engine.download(url, null, headers) { bytes ->
+      require(bytes.size.toLong() <= maxBytes - output.size) {
+        "HTTP response exceeds torrent limit"
+      }
+      output.write(bytes)
+    }
+    output.readByteArray()
+  }
+
+  fun close() {
+    if (ownsEngine) engine.close()
+  }
+
+  companion object {
+    fun default(): TorrentHttp = TorrentHttp(KtorHttpEngine(), ownsEngine = true)
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentTransport.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentTransport.kt
@@ -1,0 +1,190 @@
+package com.linroid.ketch.torrent
+
+import io.ktor.network.selector.SelectorManager
+import io.ktor.network.sockets.Datagram
+import io.ktor.network.sockets.InetSocketAddress
+import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.aSocket
+import io.ktor.network.sockets.openReadChannel
+import io.ktor.network.sockets.openWriteChannel
+import io.ktor.utils.io.readFully
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+internal expect fun createTorrentNetwork(): TorrentNetwork
+
+internal data class PeerEndpoint(val host: String, val port: Int) {
+  init {
+    require(host.isNotBlank() && host.length <= 253 && port in 0..65535)
+  }
+}
+
+internal interface TorrentConnection {
+  val remote: PeerEndpoint
+  suspend fun readExactly(size: Int): ByteArray
+  suspend fun write(bytes: ByteArray)
+  fun close()
+}
+
+internal interface TorrentListener {
+  val local: PeerEndpoint
+  suspend fun accept(): TorrentConnection
+  fun close()
+}
+
+internal data class TorrentDatagram(val remote: PeerEndpoint, val bytes: ByteArray)
+
+internal interface TorrentDatagramSocket {
+  val local: PeerEndpoint
+  suspend fun send(remote: PeerEndpoint, bytes: ByteArray)
+  suspend fun receive(): TorrentDatagram
+  fun close()
+}
+
+internal interface TorrentNetwork {
+  suspend fun connect(remote: PeerEndpoint): TorrentConnection
+  suspend fun listen(local: PeerEndpoint): TorrentListener
+  suspend fun bindUdp(local: PeerEndpoint): TorrentDatagramSocket
+  fun close()
+}
+
+/** Owns live sockets only; closing a connection removes its runtime reference immediately. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class TorrentResources {
+  private val resources = AtomicReference<List<Lease>?>(emptyList())
+
+  inner class Lease(private val action: () -> Unit) {
+    private val closed = AtomicBoolean(false)
+    fun close() {
+      if (!closed.compareAndSet(false, true)) return
+      try {
+        action()
+      } finally {
+        while (true) {
+          val current = resources.load() ?: break
+          if (resources.compareAndSet(current, current.filterNot { it === this })) break
+        }
+      }
+    }
+  }
+
+  fun register(action: () -> Unit): Lease {
+    val lease = Lease(action)
+    while (true) {
+      val current = resources.load()
+      if (current == null) {
+        lease.close()
+        error("Torrent runtime is closed")
+      }
+      if (resources.compareAndSet(current, current + lease)) return lease
+    }
+  }
+
+  val activeCount: Int get() = resources.load()?.size ?: 0
+
+  fun close() {
+    resources.exchange(null)?.forEach { lease -> runCatching { lease.close() } }
+  }
+}
+
+/** TCP/UDP adapter. Higher layers own protocol deadlines and datagram validation. */
+internal class KtorTorrentNetwork(private val connectTimeoutMs: Long = 10_000) : TorrentNetwork {
+  private val selector = SelectorManager(Dispatchers.IO)
+  private val resources = TorrentResources()
+
+  override suspend fun connect(remote: PeerEndpoint): TorrentConnection {
+    require(remote.port != 0)
+    var connection: TorrentConnection? = null
+    try {
+      withTimeout(connectTimeoutMs) {
+        connection = wrap(aSocket(selector).tcp().connect(remote.host, remote.port))
+      }
+      return checkNotNull(connection)
+    } catch (e: Throwable) {
+      connection?.close()
+      throw e
+    }
+  }
+
+  override suspend fun listen(local: PeerEndpoint): TorrentListener {
+    val socket = aSocket(selector).tcp().bind(local.host, local.port)
+    val lease = resources.register { socket.close() }
+    return object : TorrentListener {
+      override val local = endpoint(socket.localAddress as InetSocketAddress)
+      override suspend fun accept(): TorrentConnection = wrap(socket.accept())
+      override fun close() = lease.close()
+    }
+  }
+
+  override suspend fun bindUdp(local: PeerEndpoint): TorrentDatagramSocket {
+    val socket = aSocket(selector).udp().bind(local.host, local.port)
+    val lease = resources.register { socket.close() }
+    return object : TorrentDatagramSocket {
+      override val local = endpoint(socket.localAddress as InetSocketAddress)
+      override suspend fun send(remote: PeerEndpoint, bytes: ByteArray) {
+        require(bytes.size <= 65507 && remote.port != 0)
+        val packet = Buffer().apply { write(bytes) }
+        socket.send(Datagram(packet, InetSocketAddress(remote.host, remote.port)))
+      }
+      override suspend fun receive(): TorrentDatagram {
+        val datagram = socket.receive()
+        return datagram.packet.use {
+          TorrentDatagram(endpoint(datagram.address as InetSocketAddress), it.readByteArray())
+        }
+      }
+      override fun close() = lease.close()
+    }
+  }
+
+  private fun wrap(socket: Socket): TorrentConnection {
+    val lease = resources.register { socket.close() }
+    try {
+      val input = socket.openReadChannel()
+      val output = socket.openWriteChannel(autoFlush = true)
+      return object : TorrentConnection {
+        override val remote = endpoint(socket.remoteAddress as InetSocketAddress)
+        override suspend fun readExactly(size: Int): ByteArray {
+          require(size in 0..16 * 1024 * 1024)
+          return ByteArray(size).also { input.readFully(it) }
+        }
+        override suspend fun write(bytes: ByteArray) {
+          output.writeFully(bytes)
+        }
+        override fun close() = lease.close()
+      }
+    } catch (e: Throwable) {
+      lease.close()
+      throw e
+    }
+  }
+
+  override fun close() {
+    resources.close()
+    selector.close()
+  }
+
+  private fun endpoint(address: InetSocketAddress): PeerEndpoint {
+    val bytes = checkNotNull(address.resolveAddress()) { "Unresolved socket address" }
+    return PeerEndpoint(numericHost(bytes), address.port)
+  }
+}
+
+/** Keeps address families intact; reverse DNS may turn ::1 into IPv4 localhost. */
+internal fun numericHost(bytes: ByteArray): String {
+  require(bytes.size == 4 || bytes.size == 16)
+  return if (bytes.size == 4) {
+    bytes.joinToString(".") { (it.toInt() and 255).toString() }
+  } else {
+    (0 until 8).joinToString(":") { index ->
+      (((bytes[index * 2].toInt() and 255) shl 8) or
+        (bytes[index * 2 + 1].toInt() and 255)).toString(16)
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentConnectTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentConnectTest.kt
@@ -1,0 +1,29 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TorrentConnectTest {
+  @Test
+  fun unreachableFirstAddressLeavesTimeForFallback() = runTest {
+    val attempted = mutableListOf<Int>()
+    val closed = mutableListOf<Int>()
+    val result = connectTorrentCandidates(listOf(6, 4)) { family ->
+      attempted += family
+      if (family == 6) {
+        try {
+          delay(20_000)
+        } finally {
+          closed += family
+        }
+      }
+      family
+    }
+    assertEquals(4, result)
+    assertEquals(listOf(6, 4), attempted)
+    assertEquals(listOf(6), closed)
+    assertEquals(5_000L, testScheduler.currentTime)
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentFileIoTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentFileIoTest.kt
@@ -1,0 +1,41 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TorrentFileIoTest {
+  @Test
+  fun file_positionalWritesFlushReopenAndRejectReadsPastEnd() = runTest {
+    val directory = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+      "ketch-io-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+    torrentFileSystem.createDirectories(directory)
+    val path = directory / "payload"
+    try {
+      val file = TorrentFileIo.open(path)
+      try {
+        file.write(3, byteArrayOf(4, 5))
+        file.write(0, byteArrayOf(1, 2, 3))
+        file.flush()
+        assertEquals(5L, file.size())
+      } finally {
+        withContext(NonCancellable) { file.close() }
+      }
+      val reopened = TorrentFileIo.open(path)
+      try {
+        assertContentEquals(byteArrayOf(1, 2, 3, 4, 5), reopened.read(0, 5))
+        assertFailsWith<IllegalStateException> { reopened.read(4, 2) }
+        assertFailsWith<IllegalArgumentException> { reopened.read(Long.MAX_VALUE, 2) }
+      } finally {
+        withContext(NonCancellable) { reopened.close() }
+      }
+    } finally {
+      torrentFileSystem.deleteRecursively(directory)
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentHttpTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentHttpTest.kt
@@ -1,0 +1,46 @@
+package com.linroid.ketch.torrent
+
+import com.linroid.ketch.core.engine.HttpEngine
+import com.linroid.ketch.core.engine.ServerInfo
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class TorrentHttpTest {
+  private class Engine(private val delayed: Boolean = false) : HttpEngine {
+    var closed = false
+    override suspend fun head(url: String, headers: Map<String, String>): ServerInfo = error("unused")
+    override suspend fun download(
+      url: String,
+      range: LongRange?,
+      headers: Map<String, String>,
+      onData: suspend (ByteArray) -> Unit,
+    ) {
+      if (delayed) delay(10_000)
+      onData(byteArrayOf(1, 2))
+      onData(byteArrayOf(3, 4))
+    }
+    override fun close() { closed = true }
+  }
+
+  @Test
+  fun fetch_limitsAccumulatedBytesAndPreservesBorrowedEngine() = runTest {
+    val engine = Engine()
+    val http = TorrentHttp(engine)
+    assertContentEquals(byteArrayOf(1, 2, 3, 4), http.fetch("https://test", 4))
+    assertFailsWith<IllegalArgumentException> { http.fetch("https://test", 3) }
+    http.close()
+    assertFalse(engine.closed)
+  }
+
+  @Test
+  fun fetch_deadlineCancelsRequest() = runTest {
+    assertFailsWith<TimeoutCancellationException> {
+      TorrentHttp(Engine(delayed = true)).fetch("https://test", 4, timeoutMs = 100)
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentTransportTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentTransportTest.kt
@@ -1,0 +1,103 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TorrentTransportTest {
+  @Test
+  fun tcp_fragmentedWritesReadExactlyAndCloseInterruptsRead() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(10_000) {
+        val network = createTorrentNetwork()
+        try {
+          val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+          coroutineScope {
+            val accepted = async { listener.accept() }
+            val client = network.connect(listener.local)
+            val server = accepted.await()
+            client.write(byteArrayOf(1, 2))
+            client.write(byteArrayOf(3))
+            assertContentEquals(byteArrayOf(1, 2, 3), server.readExactly(3))
+            client.close()
+            assertTrue(runCatching { server.readExactly(1) }.isFailure)
+            server.close()
+          }
+          listener.close()
+        } finally {
+          network.close()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun udp_preservesPayloadAndSender() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(10_000) {
+        val network = createTorrentNetwork()
+        try {
+          val first = network.bindUdp(PeerEndpoint("127.0.0.1", 0))
+          val second = network.bindUdp(PeerEndpoint("127.0.0.1", 0))
+          first.send(second.local, byteArrayOf(0, 127, -1))
+          val datagram = second.receive()
+          assertEquals(first.local.port, datagram.remote.port)
+          assertContentEquals(byteArrayOf(0, 127, -1), datagram.bytes)
+        } finally {
+          network.close()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun ipv6_tcpAndUdpLoopback() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(10_000) {
+        val network = createTorrentNetwork()
+        try {
+          val listener = network.listen(PeerEndpoint("::1", 0))
+          coroutineScope {
+            val accept = async { listener.accept() }
+            val client = network.connect(listener.local)
+            val server = accept.await()
+            client.write(byteArrayOf(42))
+            assertContentEquals(byteArrayOf(42), server.readExactly(1))
+            val pending = async { runCatching { server.readExactly(1) } }
+            listener.close()
+            val first = network.bindUdp(PeerEndpoint("::1", 0))
+            val second = network.bindUdp(PeerEndpoint("::1", 0))
+            first.send(second.local, byteArrayOf(7))
+            assertContentEquals(byteArrayOf(7), second.receive().bytes)
+            network.close()
+            assertTrue(pending.await().isFailure)
+          }
+        } finally {
+          network.close()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun resources_connectionChurnDoesNotRetainClosedHandles() {
+    val resources = TorrentResources()
+    var closed = 0
+    repeat(1000) { resources.register { closed++ }.close() }
+    assertEquals(0, resources.activeCount)
+    resources.register { closed++ }
+    resources.close()
+    resources.close()
+    assertEquals(1001, closed)
+    assertFailsWith<IllegalStateException> { resources.register { closed++ } }
+    assertEquals(1002, closed)
+  }
+}

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PosixTorrentNetwork.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PosixTorrentNetwork.ios.kt
@@ -109,7 +109,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
     }
   }
 
-  private suspend fun resolve(endpoint: PeerEndpoint, type: Int): Address =
+  private suspend fun resolveAll(endpoint: PeerEndpoint, type: Int): List<Address> =
     withContext(Dispatchers.IO) {
       memScoped {
         val hints = alloc<addrinfo>()
@@ -121,14 +121,25 @@ internal class PosixTorrentNetwork : TorrentNetwork {
         }
         val first = checkNotNull(result.value)
         try {
-          val info = first.pointed
-          val bytes = info.ai_addr!!.reinterpret<ByteVar>().readBytes(info.ai_addrlen.toInt())
-          Address(bytes, info.ai_family)
+          val addresses = mutableListOf<Address>()
+          var current: CPointer<addrinfo>? = first
+          while (current != null && addresses.size < 16) {
+            val info = current.pointed
+            if (info.ai_family == AF_INET || info.ai_family == AF_INET6) {
+              val bytes = info.ai_addr!!.reinterpret<ByteVar>().readBytes(info.ai_addrlen.toInt())
+              addresses += Address(bytes, info.ai_family)
+            }
+            current = info.ai_next
+          }
+          addresses
         } finally {
           freeaddrinfo(first)
         }
       }
     }
+
+  private suspend fun resolve(endpoint: PeerEndpoint, type: Int): Address =
+    resolveAll(endpoint, type).first()
 
   private fun create(family: Int, type: Int): Handle {
     val fd = socket(family, type, 0)
@@ -153,7 +164,12 @@ internal class PosixTorrentNetwork : TorrentNetwork {
 
   override suspend fun connect(remote: PeerEndpoint): TorrentConnection {
     require(remote.port > 0)
-    val address = resolve(remote, SOCK_STREAM)
+    return connectTorrentCandidates(resolveAll(remote, SOCK_STREAM)) { address ->
+      connectAddress(remote, address)
+    }
+  }
+
+  private suspend fun connectAddress(remote: PeerEndpoint, address: Address): TorrentConnection {
     val handle = create(address.family, SOCK_STREAM)
     try {
       withTimeout(10_000) {

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PosixTorrentNetwork.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PosixTorrentNetwork.ios.kt
@@ -1,0 +1,373 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.linroid.ketch.torrent
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.sizeOf
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import platform.posix.AF_INET
+import platform.posix.AF_INET6
+import platform.posix.AF_UNSPEC
+import platform.posix.EAGAIN
+import platform.posix.EINPROGRESS
+import platform.posix.EINTR
+import platform.posix.EWOULDBLOCK
+import platform.posix.F_SETFL
+import platform.posix.O_NONBLOCK
+import platform.posix.POLLOUT
+import platform.posix.SO_ERROR
+import platform.posix.SO_NOSIGPIPE
+import platform.posix.SOCK_DGRAM
+import platform.posix.SOCK_STREAM
+import platform.posix.SOL_SOCKET
+import platform.posix.accept
+import platform.posix.addrinfo
+import platform.posix.bind
+import platform.posix.close
+import platform.posix.connect
+import platform.posix.errno
+import platform.posix.fcntl
+import platform.posix.freeaddrinfo
+import platform.posix.getaddrinfo
+import platform.posix.getpeername
+import platform.posix.getsockname
+import platform.posix.getsockopt
+import platform.posix.listen
+import platform.posix.poll
+import platform.posix.pollfd
+import platform.posix.recv
+import platform.posix.recvfrom
+import platform.posix.send
+import platform.posix.sendto
+import platform.posix.setsockopt
+import platform.posix.sockaddr
+import platform.posix.sockaddr_in
+import platform.posix.sockaddr_in6
+import platform.posix.sockaddr_storage
+import platform.posix.socket
+import platform.posix.socklen_tVar
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/**
+ * Nonblocking Darwin sockets. Keeps full sockaddr bytes, including IPv6 addresses/scope.
+ * Ktor 3.5.2 omits sin6_addr when packing native addresses; use OS I/O until that is fixed.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+internal class PosixTorrentNetwork : TorrentNetwork {
+  private val resources = TorrentResources()
+
+  private inner class Handle(val fd: Int) {
+    val closed = AtomicBoolean(false)
+    private val operations = AtomicInt(0)
+    private val disposed = AtomicBoolean(false)
+    private val lease = resources.register {
+      closed.store(true)
+      if (operations.load() == 0) dispose()
+    }
+    fun close() = lease.close()
+    fun checkOpen() = check(!closed.load()) { "Torrent socket closed" }
+
+    // Defer descriptor recycling until any in-flight nonblocking syscall returns.
+    fun <T> operation(block: () -> T): T {
+      operations.fetchAndAdd(1)
+      try {
+        checkOpen()
+        return block()
+      } finally {
+        if (operations.fetchAndAdd(-1) == 1 && closed.load()) dispose()
+      }
+    }
+
+    private fun dispose() {
+      if (disposed.compareAndSet(false, true)) close(fd)
+    }
+  }
+
+  private data class Address(val bytes: ByteArray, val family: Int) {
+    fun <T> use(block: (CPointer<sockaddr>, UInt) -> T): T = bytes.usePinned {
+      block(it.addressOf(0).reinterpret(), bytes.size.toUInt())
+    }
+  }
+
+  private suspend fun resolve(endpoint: PeerEndpoint, type: Int): Address =
+    withContext(Dispatchers.IO) {
+      memScoped {
+        val hints = alloc<addrinfo>()
+        hints.ai_family = AF_UNSPEC
+        hints.ai_socktype = type
+        val result = alloc<CPointerVar<addrinfo>>()
+        check(getaddrinfo(endpoint.host, endpoint.port.toString(), hints.ptr, result.ptr) == 0) {
+          "Cannot resolve torrent endpoint"
+        }
+        val first = checkNotNull(result.value)
+        try {
+          val info = first.pointed
+          val bytes = info.ai_addr!!.reinterpret<ByteVar>().readBytes(info.ai_addrlen.toInt())
+          Address(bytes, info.ai_family)
+        } finally {
+          freeaddrinfo(first)
+        }
+      }
+    }
+
+  private fun create(family: Int, type: Int): Handle {
+    val fd = socket(family, type, 0)
+    check(fd >= 0) { "Cannot create torrent socket: $errno" }
+    return configure(fd)
+  }
+
+  private fun configure(fd: Int): Handle {
+    try {
+      check(fcntl(fd, F_SETFL, O_NONBLOCK) == 0) { "Cannot set nonblocking socket" }
+      memScoped {
+        val enabled = alloc<IntVar>()
+        enabled.value = 1
+        check(setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, enabled.ptr, sizeOf<IntVar>().toUInt()) == 0)
+      }
+    } catch (e: Throwable) {
+      close(fd)
+      throw e
+    }
+    return Handle(fd)
+  }
+
+  override suspend fun connect(remote: PeerEndpoint): TorrentConnection {
+    require(remote.port > 0)
+    val address = resolve(remote, SOCK_STREAM)
+    val handle = create(address.family, SOCK_STREAM)
+    try {
+      withTimeout(10_000) {
+        val status = address.use { pointer, size ->
+          handle.operation { connect(handle.fd, pointer, size) }
+        }
+        if (status != 0) {
+          check(errno == EINPROGRESS || errno == EINTR) { "Torrent connect failed: $errno" }
+          while (true) {
+            handle.checkOpen()
+            val ready = memScoped {
+              val descriptor = alloc<pollfd>()
+              descriptor.fd = handle.fd
+              descriptor.events = POLLOUT.toShort()
+              handle.operation { poll(descriptor.ptr, 1u, 0) }
+            }
+            if (ready > 0) break
+            delay(5)
+          }
+          memScoped {
+            val error = alloc<IntVar>()
+            val size = alloc<socklen_tVar>()
+            size.value = sizeOf<IntVar>().toUInt()
+            val result = handle.operation {
+              getsockopt(handle.fd, SOL_SOCKET, SO_ERROR, error.ptr, size.ptr)
+            }
+            check(result == 0)
+            check(error.value == 0) { "Torrent connect failed: ${error.value}" }
+          }
+        }
+      }
+      return connection(handle, remote)
+    } catch (e: Throwable) {
+      handle.close()
+      throw e
+    }
+  }
+
+  override suspend fun listen(local: PeerEndpoint): TorrentListener {
+    val address = resolve(local, SOCK_STREAM)
+    val handle = create(address.family, SOCK_STREAM)
+    try {
+      val bound = address.use { pointer, size ->
+        handle.operation { bind(handle.fd, pointer, size) }
+      }
+      check(bound == 0)
+      check(handle.operation { listen(handle.fd, 64) } == 0)
+      return object : TorrentListener {
+        override val local = localEndpoint(handle)
+        override suspend fun accept(): TorrentConnection {
+          while (true) {
+            handle.checkOpen()
+            currentCoroutineContext().ensureActive()
+            val fd = handle.operation { accept(handle.fd, null, null) }
+            if (fd >= 0) {
+              val accepted = configure(fd)
+              try {
+                val remote = memScoped {
+                  val storage = alloc<sockaddr_storage>()
+                  val size = alloc<socklen_tVar>()
+                  size.value = sizeOf<sockaddr_storage>().toUInt()
+                  val result = accepted.operation {
+                    getpeername(fd, storage.ptr.reinterpret(), size.ptr)
+                  }
+                  check(result == 0)
+                  endpoint(storage.ptr.reinterpret())
+                }
+                return connection(accepted, remote)
+              } catch (e: Throwable) {
+                accepted.close()
+                throw e
+              }
+            }
+            retry()
+          }
+        }
+        override fun close() = handle.close()
+      }
+    } catch (e: Throwable) {
+      handle.close()
+      throw e
+    }
+  }
+
+  override suspend fun bindUdp(local: PeerEndpoint): TorrentDatagramSocket {
+    val address = resolve(local, SOCK_DGRAM)
+    val handle = create(address.family, SOCK_DGRAM)
+    try {
+      val bound = address.use { pointer, size ->
+        handle.operation { bind(handle.fd, pointer, size) }
+      }
+      check(bound == 0)
+      return object : TorrentDatagramSocket {
+        override val local = localEndpoint(handle)
+        override suspend fun send(remote: PeerEndpoint, bytes: ByteArray) {
+          require(bytes.isNotEmpty() && bytes.size <= 65507 && remote.port > 0)
+          val target = resolve(remote, SOCK_DGRAM)
+          while (true) {
+            handle.checkOpen()
+            currentCoroutineContext().ensureActive()
+            val written = bytes.usePinned { data ->
+              target.use { pointer, size ->
+                handle.operation {
+                  sendto(handle.fd, data.addressOf(0), bytes.size.toULong(), 0, pointer, size)
+                }
+              }
+            }
+            if (written >= 0) {
+              check(written.toInt() == bytes.size) { "Short datagram write" }
+              return
+            }
+            retry()
+          }
+        }
+        override suspend fun receive(): TorrentDatagram {
+          val bytes = ByteArray(65536)
+          while (true) {
+            handle.checkOpen()
+            currentCoroutineContext().ensureActive()
+            val result = memScoped {
+              val storage = alloc<sockaddr_storage>()
+              val size = alloc<socklen_tVar>()
+              size.value = sizeOf<sockaddr_storage>().toUInt()
+              val count = bytes.usePinned {
+                handle.operation {
+                  recvfrom(handle.fd, it.addressOf(0), bytes.size.toULong(), 0,
+                    storage.ptr.reinterpret(), size.ptr)
+                }
+              }
+              if (count < 0) null else TorrentDatagram(
+                endpoint(storage.ptr.reinterpret()), bytes.copyOf(count.toInt())
+              )
+            }
+            if (result != null) return result
+            retry()
+          }
+        }
+        override fun close() = handle.close()
+      }
+    } catch (e: Throwable) {
+      handle.close()
+      throw e
+    }
+  }
+
+  private fun connection(handle: Handle, endpoint: PeerEndpoint): TorrentConnection =
+    object : TorrentConnection {
+      override val remote = endpoint
+      override suspend fun readExactly(size: Int): ByteArray {
+        require(size in 0..16 * 1024 * 1024)
+        val bytes = ByteArray(size)
+        var offset = 0
+        while (offset < size) {
+          handle.checkOpen()
+          currentCoroutineContext().ensureActive()
+          val count = bytes.usePinned {
+            handle.operation { recv(handle.fd, it.addressOf(offset), (size - offset).toULong(), 0) }
+          }
+          check(count != 0L) { "Torrent peer disconnected" }
+          if (count < 0) retry() else offset += count.toInt()
+        }
+        return bytes
+      }
+      override suspend fun write(bytes: ByteArray) {
+        var offset = 0
+        while (offset < bytes.size) {
+          handle.checkOpen()
+          currentCoroutineContext().ensureActive()
+          val count = bytes.usePinned {
+            handle.operation {
+              send(handle.fd, it.addressOf(offset), (bytes.size - offset).toULong(), 0)
+            }
+          }
+          if (count < 0) retry() else {
+            check(count > 0) { "Short torrent socket write" }
+            offset += count.toInt()
+          }
+        }
+      }
+      override fun close() = handle.close()
+    }
+
+  private suspend fun retry() {
+    val error = errno
+    check(error == EAGAIN || error == EWOULDBLOCK || error == EINTR) {
+      "Torrent socket I/O failed: $error"
+    }
+    delay(5)
+  }
+
+  private fun localEndpoint(handle: Handle): PeerEndpoint = memScoped {
+    val storage = alloc<sockaddr_storage>()
+    val size = alloc<socklen_tVar>()
+    size.value = sizeOf<sockaddr_storage>().toUInt()
+    check(handle.operation { getsockname(handle.fd, storage.ptr.reinterpret(), size.ptr) } == 0)
+    endpoint(storage.ptr.reinterpret())
+  }
+
+  private fun endpoint(address: CPointer<sockaddr>): PeerEndpoint {
+    val header = address.reinterpret<ByteVar>().readBytes(4)
+    val port = ((header[2].toInt() and 255) shl 8) or (header[3].toInt() and 255)
+    val host = when (address.pointed.sa_family.toInt()) {
+      AF_INET -> numericHost(
+        address.reinterpret<sockaddr_in>().pointed.sin_addr.ptr.reinterpret<ByteVar>().readBytes(4)
+      )
+      AF_INET6 -> {
+        val value = address.reinterpret<sockaddr_in6>().pointed
+        val host = numericHost(value.sin6_addr.ptr.reinterpret<ByteVar>().readBytes(16))
+        if (value.sin6_scope_id == 0u) host else "$host%${value.sin6_scope_id}"
+      }
+      else -> error("Unsupported address family")
+    }
+    return PeerEndpoint(host, port)
+  }
+
+  override fun close() = resources.close()
+}

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/TorrentIo.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/TorrentIo.ios.kt
@@ -1,0 +1,16 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import okio.FileSystem
+import platform.posix.arc4random_buf
+
+internal actual val torrentFileSystem: FileSystem = FileSystem.SYSTEM
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun torrentRandomBytes(size: Int): ByteArray = ByteArray(size).also { bytes ->
+  if (size > 0) bytes.usePinned { arc4random_buf(it.addressOf(0), size.toULong()) }
+}
+
+internal actual fun createTorrentNetwork(): TorrentNetwork = PosixTorrentNetwork()

--- a/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/TorrentIo.jvmAndAndroid.kt
+++ b/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/TorrentIo.jvmAndAndroid.kt
@@ -1,0 +1,11 @@
+package com.linroid.ketch.torrent
+
+import okio.FileSystem
+import java.security.SecureRandom
+
+internal actual val torrentFileSystem: FileSystem = FileSystem.SYSTEM
+private val secureRandom = SecureRandom()
+internal actual fun torrentRandomBytes(size: Int): ByteArray =
+  ByteArray(size).also { secureRandom.nextBytes(it) }
+
+internal actual fun createTorrentNetwork(): TorrentNetwork = KtorTorrentNetwork()


### PR DESCRIPTION
Adds portable TCP/UDP connections and listeners backed by Ktor on JVM/Android and a nonblocking OS-socket adapter on iOS, plus bounded HTTP fetching and serialized positional file I/O. The socket owner removes closed connections immediately and releases live sockets on shutdown. File close is cancellation-safe, and canceled file opens release their handle. Randomness and filesystem adapters support JVM/Android and iOS without torrent native bindings.

Validation: torrent JVM, Android host and enabled iOS simulator suites, including real IPv4/IPv6 TCP and UDP loopback, fragmented reads, shutdown during reads, resource churn, file flush/reopen, bounds and injected HTTP timeout/size tests. HTTP unit tests validate adapter behavior; independent TLS interoperability remains part of integration validation.

Stack: 03/14. Base: #148. Previous: #147. Next: peer wire protocol.

The pinned Ktor 3.5.2 native IPv6 sockaddr packing omits the destination address; an IPv6 UDP loopback test exposed the failure. The iOS adapter preserves complete OS sockaddr data and defers descriptor recycling while a syscall is active. Its nonblocking I/O currently polls with coroutine delays; CPU/throughput measurements remain required in the final performance gate.
