### PR TITLE
feat(torrent): implement peer wire protocol and request state

### DIFF
--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerProtocolState.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerProtocolState.kt
@@ -1,0 +1,71 @@
+package com.linroid.ketch.torrent
+
+/** Per-connection availability and request ownership, independent of the swarm scheduler. */
+internal class PeerProtocolState(pieceCount: Int, private val maxPending: Int = 32) {
+  init {
+    require(pieceCount in 0..209_715 && maxPending in 1..256)
+  }
+
+  val available: BooleanArray = BooleanArray(pieceCount)
+  var choking: Boolean = true
+    private set
+  var interested: Boolean = false
+    private set
+  private var availabilitySeen = false
+  private val pending = mutableSetOf<PeerMessage.Request>()
+  private val canceled = linkedSetOf<PeerMessage.Request>()
+  val requests: Set<PeerMessage.Request> get() = pending.toSet()
+
+  fun requested(request: PeerMessage.Request) {
+    check(!choking) { "Peer is choking" }
+    require(request.index in available.indices && available[request.index]) { "Peer lacks piece" }
+    require(pending.size < maxPending && request !in pending) {
+      "Peer pipeline is full or duplicated"
+    }
+    canceled.remove(request)
+    pending.add(request)
+  }
+
+  fun cancel(request: PeerMessage.Request) {
+    if (pending.remove(request)) {
+      canceled.add(request)
+      while (canceled.size > maxPending * 2) canceled.remove(canceled.first())
+    }
+  }
+
+  /** Returns false for a late response to a canceled request. */
+  fun received(message: PeerMessage): Boolean {
+    when (message) {
+      is PeerMessage.Control -> when (message.signal) {
+        PeerMessage.Signal.CHOKE -> {
+          choking = true
+          pending.toList().forEach(::cancel)
+        }
+        PeerMessage.Signal.UNCHOKE -> choking = false
+        PeerMessage.Signal.INTERESTED -> interested = true
+        PeerMessage.Signal.NOT_INTERESTED -> interested = false
+      }
+      is PeerMessage.Have -> {
+        require(message.index in available.indices)
+        availabilitySeen = true
+        available[message.index] = true
+      }
+      is PeerMessage.Bitfield -> {
+        require(!availabilitySeen) { "Repeated or late bitfield" }
+        require(message.bytes.size == (available.size + 7) / 8)
+        availabilitySeen = true
+        for (index in available.indices) {
+          available[index] = message.bytes[index / 8].toInt() and (128 ushr (index % 8)) != 0
+        }
+      }
+      is PeerMessage.Piece -> {
+        val request = PeerMessage.Request(message.index, message.begin, message.bytes.size)
+        if (pending.remove(request)) return true
+        if (request in canceled) return false
+        throw IllegalArgumentException("Unsolicited or mismatched peer block")
+      }
+      else -> Unit
+    }
+    return true
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerWire.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerWire.kt
@@ -1,0 +1,186 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.withTimeout
+import okio.Buffer
+
+internal sealed interface PeerMessage {
+  data object KeepAlive : PeerMessage
+  enum class Signal { CHOKE, UNCHOKE, INTERESTED, NOT_INTERESTED }
+  data class Control(val signal: Signal) : PeerMessage
+  data class Have(val index: Int) : PeerMessage
+  data class Bitfield(val bytes: ByteArray) : PeerMessage
+  data class Request(val index: Int, val begin: Int, val length: Int) : PeerMessage
+  data class Piece(val index: Int, val begin: Int, val bytes: ByteArray) : PeerMessage
+  data class Cancel(val index: Int, val begin: Int, val length: Int) : PeerMessage
+  data class Port(val port: Int) : PeerMessage
+  data class Extended(val id: Int, val payload: ByteArray) : PeerMessage
+  data class Unknown(val id: Int, val payload: ByteArray) : PeerMessage
+}
+
+internal data class PeerHandshake(
+  val infoHash: InfoHash,
+  val peerId: ByteArray,
+  val extensions: Boolean,
+  val dht: Boolean,
+)
+
+/** Wire codec with bounded allocations; sessions enforce message ordering and request ownership. */
+internal class PeerWire(
+  private val connection: TorrentConnection,
+  private val metadata: TorrentMetadata? = null,
+  private val idleTimeoutMs: Long = 120_000,
+) {
+  suspend fun handshake(local: PeerHandshake): PeerHandshake = withTimeout(10_000) {
+    connection.write(encodeHandshake(local))
+    decodeHandshake(connection.readExactly(68), local.infoHash)
+  }
+
+  suspend fun read(): PeerMessage = withTimeout(idleTimeoutMs) {
+    val size = Buffer().write(connection.readExactly(4)).readInt()
+    require(size in 0..MAX_FRAME_SIZE) { "Peer frame exceeds limit" }
+    decode(connection.readExactly(size), metadata)
+  }
+
+  suspend fun send(message: PeerMessage) = withTimeout(idleTimeoutMs) {
+    connection.write(encode(message, metadata))
+  }
+
+  companion object {
+    const val BLOCK_SIZE: Int = 16 * 1024
+    const val MAX_FRAME_SIZE: Int = 64 * 1024
+    private val protocol = "BitTorrent protocol".encodeToByteArray()
+
+    fun encodeHandshake(handshake: PeerHandshake): ByteArray {
+      require(handshake.peerId.size == 20)
+      val reserved = ByteArray(8)
+      if (handshake.extensions) reserved[5] = 0x10
+      if (handshake.dht) reserved[7] = 1
+      return Buffer().writeByte(19).write(protocol).write(reserved)
+        .write(handshake.infoHash.toBytes()).write(handshake.peerId).readByteArray()
+    }
+
+    fun decodeHandshake(bytes: ByteArray, expected: InfoHash): PeerHandshake {
+      require(bytes.size == 68 && bytes[0] == 19.toByte()) { "Invalid peer handshake length" }
+      require(bytes.copyOfRange(1, 20).contentEquals(protocol)) { "Unknown peer protocol" }
+      val hash = InfoHash.fromBytes(bytes.copyOfRange(28, 48))
+      require(hash == expected) { "Peer belongs to another swarm" }
+      return PeerHandshake(
+        infoHash = hash,
+        peerId = bytes.copyOfRange(48, 68),
+        extensions = bytes[25].toInt() and 0x10 != 0,
+        dht = bytes[27].toInt() and 1 != 0,
+      )
+    }
+
+    fun decode(payload: ByteArray, metadata: TorrentMetadata? = null): PeerMessage {
+      require(payload.size <= MAX_FRAME_SIZE)
+      if (payload.isEmpty()) return PeerMessage.KeepAlive
+      val input = Buffer().write(payload)
+      val id = input.readByte().toInt() and 255
+      fun exact(size: Int) = require(input.size == size.toLong()) { "Invalid peer message length" }
+      val message = when (id) {
+        in 0..3 -> {
+          exact(0)
+          PeerMessage.Control(PeerMessage.Signal.entries[id])
+        }
+        4 -> {
+          exact(4)
+          PeerMessage.Have(input.readInt())
+        }
+        5 -> PeerMessage.Bitfield(input.readByteArray())
+        6, 8 -> {
+          exact(12)
+          val index = input.readInt()
+          val begin = input.readInt()
+          val length = input.readInt()
+          if (id == 6) PeerMessage.Request(index, begin, length)
+          else PeerMessage.Cancel(index, begin, length)
+        }
+        7 -> {
+          require(input.size >= 9) { "Empty or truncated peer block" }
+          PeerMessage.Piece(input.readInt(), input.readInt(), input.readByteArray())
+        }
+        9 -> {
+          exact(2)
+          PeerMessage.Port(input.readShort().toInt() and 65535)
+        }
+        20 -> {
+          require(input.size >= 1)
+          PeerMessage.Extended(input.readByte().toInt() and 255, input.readByteArray())
+        }
+        else -> PeerMessage.Unknown(id, input.readByteArray())
+      }
+      validate(message, metadata)
+      return message
+    }
+
+    fun encode(message: PeerMessage, metadata: TorrentMetadata? = null): ByteArray {
+      validate(message, metadata)
+      val out = Buffer()
+      when (message) {
+        PeerMessage.KeepAlive -> Unit
+        is PeerMessage.Control -> out.writeByte(message.signal.ordinal)
+        is PeerMessage.Have -> out.writeByte(4).writeInt(message.index)
+        is PeerMessage.Bitfield -> out.writeByte(5).write(message.bytes)
+        is PeerMessage.Request -> out.writeByte(6).writeInt(message.index)
+          .writeInt(message.begin).writeInt(message.length)
+        is PeerMessage.Piece -> out.writeByte(7).writeInt(message.index)
+          .writeInt(message.begin).write(message.bytes)
+        is PeerMessage.Cancel -> out.writeByte(8).writeInt(message.index)
+          .writeInt(message.begin).writeInt(message.length)
+        is PeerMessage.Port -> out.writeByte(9).writeShort(message.port)
+        is PeerMessage.Extended -> out.writeByte(20).writeByte(message.id).write(message.payload)
+        is PeerMessage.Unknown -> out.writeByte(message.id).write(message.payload)
+      }
+      require(out.size <= MAX_FRAME_SIZE)
+      return Buffer().writeInt(out.size.toInt()).write(out.readByteArray()).readByteArray()
+    }
+
+    private fun validate(message: PeerMessage, metadata: TorrentMetadata?) {
+      when (message) {
+        is PeerMessage.Have -> validateIndex(message.index, metadata)
+        is PeerMessage.Request ->
+          validateBlock(message.index, message.begin, message.length, metadata)
+        is PeerMessage.Cancel ->
+          validateBlock(message.index, message.begin, message.length, metadata)
+        is PeerMessage.Piece ->
+          validateBlock(message.index, message.begin, message.bytes.size, metadata)
+        is PeerMessage.Bitfield -> {
+          require(message.bytes.size < MAX_FRAME_SIZE)
+          if (metadata != null) {
+            val count = metadata.pieceHashes.size / 20
+            require(message.bytes.size == (count + 7) / 8) { "Wrong bitfield size" }
+            val spare = (8 - count % 8) % 8
+            if (spare != 0) {
+              require(message.bytes.last().toInt() and ((1 shl spare) - 1) == 0) {
+                "Nonzero bitfield padding"
+              }
+            }
+          }
+        }
+        is PeerMessage.Port -> require(message.port in 1..65535)
+        is PeerMessage.Extended -> require(message.id in 0..255)
+        is PeerMessage.Unknown -> require(message.id in 0..255)
+        else -> Unit
+      }
+    }
+
+    private fun validateIndex(index: Int, metadata: TorrentMetadata?) {
+      require(index >= 0) { "Negative piece index" }
+      if (metadata != null) {
+        require(index < metadata.pieceHashes.size / 20) { "Invalid piece index" }
+      }
+    }
+
+    private fun validateBlock(index: Int, begin: Int, length: Int, metadata: TorrentMetadata?) {
+      validateIndex(index, metadata)
+      require(begin >= 0 && length in 1..BLOCK_SIZE) { "Invalid block bounds" }
+      if (metadata != null) {
+        val pieceSize = minOf(
+          metadata.pieceLength, metadata.totalBytes - index * metadata.pieceLength
+        )
+        require(begin.toLong() <= pieceSize - length) { "Block exceeds piece" }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerWire.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerWire.kt
@@ -28,7 +28,7 @@ internal data class PeerHandshake(
 internal class PeerWire(
   private val connection: TorrentConnection,
   private val metadata: TorrentMetadata? = null,
-  private val idleTimeoutMs: Long = 120_000,
+  private val idleTimeoutMs: Long = 180_000,
 ) {
   suspend fun handshake(local: PeerHandshake): PeerHandshake = withTimeout(10_000) {
     connection.write(encodeHandshake(local))

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerProtocolStateTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerProtocolStateTest.kt
@@ -1,0 +1,43 @@
+package com.linroid.ketch.torrent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PeerProtocolStateTest {
+  @Test
+  fun request_enforcesChokingAvailabilityAndPipeline() {
+    val state = PeerProtocolState(2, maxPending = 1)
+    val first = PeerMessage.Request(0, 0, 16)
+    assertFailsWith<IllegalStateException> { state.requested(first) }
+    state.received(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+    assertFailsWith<IllegalArgumentException> { state.requested(first) }
+    state.received(PeerMessage.Bitfield(byteArrayOf(-64)))
+    state.requested(first)
+    assertFailsWith<IllegalArgumentException> { state.requested(PeerMessage.Request(1, 0, 16)) }
+    assertFailsWith<IllegalArgumentException> {
+      state.received(PeerMessage.Piece(0, 0, ByteArray(15)))
+    }
+    assertTrue(state.received(PeerMessage.Piece(0, 0, ByteArray(16))))
+    assertTrue(state.requests.isEmpty())
+  }
+
+  @Test
+  fun choke_clearsPipelineAndIgnoresLateCanceledBlocks() {
+    val state = PeerProtocolState(1)
+    state.received(PeerMessage.Have(0))
+    state.received(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+    state.requested(PeerMessage.Request(0, 0, 16))
+    state.received(PeerMessage.Control(PeerMessage.Signal.CHOKE))
+    assertEquals(emptySet(), state.requests)
+    assertFalse(state.received(PeerMessage.Piece(0, 0, ByteArray(16))))
+    assertFailsWith<IllegalArgumentException> {
+      state.received(PeerMessage.Piece(0, 16, ByteArray(16)))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      state.received(PeerMessage.Bitfield(byteArrayOf(-128)))
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerWireTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerWireTest.kt
@@ -1,0 +1,95 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class PeerWireTest {
+  private val hash = InfoHash.fromBytes(ByteArray(20))
+  private val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+    "name" to "file", "piece length" to 16384L, "length" to 16387L, "pieces" to ByteArray(40)
+  ))))
+
+  @Test
+  fun handshake_validatesProtocolAndSwarm() {
+    val bytes = PeerWire.encodeHandshake(PeerHandshake(hash, ByteArray(20) { 7 }, true, true))
+    assertEquals(68, bytes.size)
+    val result = PeerWire.decodeHandshake(bytes, hash)
+    assertContentEquals(ByteArray(20) { 7 }, result.peerId)
+    assertTrue(result.extensions && result.dht)
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.decodeHandshake(bytes, InfoHash.fromBytes(ByteArray(20) { 1 }))
+    }
+    bytes[1] = 0
+    assertFailsWith<IllegalArgumentException> { PeerWire.decodeHandshake(bytes, hash) }
+  }
+
+  @Test
+  fun piece_shortFinalBlockAcceptedAndOutOfBoundsRejected() {
+    val encoded = PeerWire.encode(PeerMessage.Piece(1, 0, byteArrayOf(1, 2, 3)), metadata)
+    val piece = assertIs<PeerMessage.Piece>(
+      PeerWire.decode(encoded.copyOfRange(4, encoded.size), metadata)
+    )
+    assertEquals(1, piece.index)
+    assertContentEquals(byteArrayOf(1, 2, 3), piece.bytes)
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.encode(PeerMessage.Request(1, 0, 4), metadata)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.encode(PeerMessage.Request(2, 0, 1), metadata)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.encode(PeerMessage.Request(0, -1, 1), metadata)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.encode(PeerMessage.Request(0, 0, 16385), metadata)
+    }
+  }
+
+  @Test
+  fun decode_malformedLengthsAndBitfieldsRejected() {
+    for (payload in listOf(byteArrayOf(0, 1), byteArrayOf(4), byteArrayOf(6, 0),
+      byteArrayOf(7, 0), byteArrayOf(9, 0), byteArrayOf(20))) {
+      assertFailsWith<IllegalArgumentException> { PeerWire.decode(payload, metadata) }
+    }
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.decode(byteArrayOf(5, 1), metadata)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      PeerWire.decode(byteArrayOf(5, -64, 0), metadata)
+    }
+    assertIs<PeerMessage.Bitfield>(PeerWire.decode(byteArrayOf(5, -64), metadata))
+  }
+
+  @Test
+  fun read_rejectsHugeFrameBeforeReadingPayload() = runTest {
+    val requested = mutableListOf<Int>()
+    val connection = object : TorrentConnection {
+      override val remote = PeerEndpoint("127.0.0.1", 1)
+      override suspend fun readExactly(size: Int): ByteArray {
+        requested.add(size)
+        return Buffer().writeInt(Int.MAX_VALUE).readByteArray()
+      }
+      override suspend fun write(bytes: ByteArray) = Unit
+      override fun close() = Unit
+    }
+    assertFailsWith<IllegalArgumentException> { PeerWire(connection).read() }
+    assertEquals(listOf(4), requested)
+  }
+
+  @Test
+  fun messages_knownWireEncodingAndUnknownExtensions() {
+    assertContentEquals(
+      byteArrayOf(0, 0, 0, 1, 2),
+      PeerWire.encode(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
+    )
+    assertContentEquals(byteArrayOf(0, 0, 0, 0), PeerWire.encode(PeerMessage.KeepAlive))
+    val unknown = assertIs<PeerMessage.Unknown>(PeerWire.decode(byteArrayOf(99, 1, 2)))
+    assertContentEquals(byteArrayOf(1, 2), unknown.payload)
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerWireTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerWireTest.kt
@@ -1,5 +1,6 @@
 package com.linroid.ketch.torrent
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import okio.Buffer
 import kotlin.test.Test
@@ -10,6 +11,20 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class PeerWireTest {
+  @Test
+  fun acceptsTwoMinuteKeepaliveWithSchedulingSlack() = runTest {
+    val connection = object : TorrentConnection {
+      override val remote = PeerEndpoint("127.0.0.1", 1)
+      override suspend fun readExactly(size: Int): ByteArray {
+        if (size == 4) delay(125_000)
+        return ByteArray(size)
+      }
+      override suspend fun write(bytes: ByteArray) = Unit
+      override fun close() = Unit
+    }
+    assertEquals(PeerMessage.KeepAlive, PeerWire(connection).read())
+  }
+
   private val hash = InfoHash.fromBytes(ByteArray(20))
   private val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
     "name" to "file", "piece length" to 16384L, "length" to 16387L, "pieces" to ByteArray(40)


### PR DESCRIPTION
Implements BitTorrent v1 handshakes and framed peer messages with bounds checked before allocation. Verifies swarm identity, bitfield length/padding, block offsets and final-piece lengths, and preserves unknown extension payloads for higher-layer handling. Adds handshake, read and write deadlines.

Adds per-peer availability, choking and bounded request ownership. Unsolicited or mismatched blocks fail; bounded late responses to canceled requests are ignored. Swarm scheduling and disk verification follow in later layers.

Validation: torrent JVM, Android host, and enabled iOS simulator suites passed. Tests cover known wire encodings, malformed lengths, oversized frames, short final blocks, choking, availability and cancellation.

Stack: 04/14. Base: #149. Next: verified multi-file storage.
