### PR TITLE
feat(torrent): verified TCP transfer and reference seeder interoperability

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -9,8 +9,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 02 Metainfo and hashing | https://github.com/linroid/Ketch/pull/148 | Draft; local JVM/Android/iOS gates passed |
 | 03 Portable I/O | https://github.com/linroid/Ketch/pull/149 | Draft; real IPv4/IPv6 TCP/UDP and filesystem tests passed on JVM/Android/iOS |
 | 04 Peer wire/state | https://github.com/linroid/Ketch/pull/150 | Draft; local JVM/Android/iOS gates passed |
-| 05 Verified storage | Pending | Validation in progress |
-| 06–14 | Pending | Not implemented yet |
+| 05 Verified storage | https://github.com/linroid/Ketch/pull/152 | Draft; local JVM/Android/iOS gates passed |
+| 06 First verified transfer | Pending PR | JVM independent libtorrent seeder passed; JVM/Android/iOS loopback transfer and corruption gates passed |
+| 07–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerProtocolState.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerProtocolState.kt
@@ -22,18 +22,22 @@ internal class PeerProtocolState(pieceCount: Int, private val maxPending: Int = 
     require(pending.size < maxPending && request !in pending) {
       "Peer pipeline is full or duplicated"
     }
-    canceled.remove(request)
     pending.add(request)
   }
 
   fun cancel(request: PeerMessage.Request) {
     if (pending.remove(request)) {
-      canceled.add(request)
-      while (canceled.size > maxPending * 2) canceled.remove(canceled.first())
+      remember(request)
     }
   }
 
-  /** Returns false for a late response to a canceled request. */
+  private fun remember(request: PeerMessage.Request) {
+    canceled.remove(request)
+    canceled.add(request)
+    while (canceled.size > maxPending * 2) canceled.remove(canceled.first())
+  }
+
+  /** Returns false for a late response to a canceled or already completed request. */
   fun received(message: PeerMessage): Boolean {
     when (message) {
       is PeerMessage.Control -> when (message.signal) {
@@ -60,7 +64,10 @@ internal class PeerProtocolState(pieceCount: Int, private val maxPending: Int = 
       }
       is PeerMessage.Piece -> {
         val request = PeerMessage.Request(message.index, message.begin, message.bytes.size)
-        if (pending.remove(request)) return true
+        if (pending.remove(request)) {
+          remember(request)
+          return true
+        }
         if (request in canceled) return false
         throw IllegalArgumentException("Unsolicited or mismatched peer block")
       }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloader.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloader.kt
@@ -1,0 +1,84 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+/** First peer-to-storage transfer path. Swarm scheduling composes this protocol in layer 08. */
+internal class TorrentPeerDownloader(
+  private val store: TorrentPieceStore,
+  private val network: TorrentNetwork,
+  private val consumePayload: suspend (Int) -> Unit = {},
+  private val onProgress: suspend (Long) -> Unit = {},
+) {
+  suspend fun download(endpoint: PeerEndpoint) {
+    store.initialize()
+    if (store.completed()) {
+      store.finish()
+      return
+    }
+    val metadata = store.metadata
+    val verified = store.verifiedPieces()
+    val connection = network.connect(endpoint)
+    try {
+      val wire = PeerWire(connection, metadata, idleTimeoutMs = 30_000)
+      val peerId = torrentRandomBytes(20)
+      val handshake = wire.handshake(PeerHandshake(metadata.infoHash, peerId, false, false))
+      require(!handshake.peerId.contentEquals(peerId)) { "Connected to ourselves" }
+      val state = PeerProtocolState(store.pieceCount, maxPending = 1)
+      wire.send(PeerMessage.Bitfield(pieceBitfield(verified)))
+      wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
+      var piece = -1
+      var assembled = ByteArray(0)
+      var offset = 0
+      while (!store.completed()) {
+        currentCoroutineContext().ensureActive()
+        val message = wire.read()
+        if (message is PeerMessage.Piece) consumePayload(message.bytes.size)
+        val accepted = state.received(message)
+        if (message is PeerMessage.Piece && accepted) {
+          check(message.index == piece && message.begin == offset)
+          message.bytes.copyInto(assembled, offset)
+          offset += message.bytes.size
+          if (offset == assembled.size) {
+            require(store.commit(piece, assembled)) { "Peer sent a corrupt piece" }
+            verified[piece] = true
+            if (!store.completed()) wire.send(PeerMessage.Have(piece))
+            onProgress(store.progress().sum())
+            piece = -1
+            assembled = ByteArray(0)
+            offset = 0
+          }
+        }
+        if (!state.choking && state.requests.isEmpty()) {
+          if (piece == -1) {
+            piece = verified.indices.firstOrNull {
+              store.needed(it) && !verified[it] && state.available[it]
+            } ?: -1
+            if (piece != -1) assembled = ByteArray(store.pieceSize(piece))
+          }
+          if (piece != -1) {
+            val request = PeerMessage.Request(
+              index = piece,
+              begin = offset,
+              length = minOf(PeerWire.BLOCK_SIZE, assembled.size - offset),
+            )
+            state.requested(request)
+            wire.send(request)
+          }
+        }
+      }
+      store.finish()
+    } finally {
+      connection.close()
+    }
+  }
+}
+
+internal fun pieceBitfield(pieces: BooleanArray): ByteArray {
+  val bits = ByteArray((pieces.size + 7) / 8)
+  for (index in pieces.indices) {
+    if (pieces[index]) bits[index / 8] =
+      (bits[index / 8].toInt() or (128 ushr (index % 8))).toByte()
+  }
+  return bits
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloader.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloader.kt
@@ -2,6 +2,9 @@ package com.linroid.ketch.torrent
 
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeout
+import okio.IOException
+import kotlin.time.TimeSource
 
 /** First peer-to-storage transfer path. Swarm scheduling composes this protocol in layer 08. */
 internal class TorrentPeerDownloader(
@@ -9,6 +12,7 @@ internal class TorrentPeerDownloader(
   private val network: TorrentNetwork,
   private val consumePayload: suspend (Int) -> Unit = {},
   private val onProgress: suspend (Long) -> Unit = {},
+  private val timeSource: TimeSource = TimeSource.Monotonic,
 ) {
   suspend fun download(endpoint: PeerEndpoint) {
     store.initialize()
@@ -30,12 +34,16 @@ internal class TorrentPeerDownloader(
       var piece = -1
       var assembled = ByteArray(0)
       var offset = 0
+      var lastProgress = timeSource.markNow()
       while (!store.completed()) {
         currentCoroutineContext().ensureActive()
-        val message = wire.read()
+        val remaining = 30_000 - lastProgress.elapsedNow().inWholeMilliseconds
+        if (remaining <= 0) throw IOException("Peer made no payload progress")
+        val message = withTimeout(remaining) { wire.read() }
         if (message is PeerMessage.Piece) consumePayload(message.bytes.size)
         val accepted = state.received(message)
         if (message is PeerMessage.Piece && accepted) {
+          lastProgress = timeSource.markNow()
           check(message.index == piece && message.begin == offset)
           message.bytes.copyInto(assembled, offset)
           offset += message.bytes.size

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerProtocolStateTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerProtocolStateTest.kt
@@ -8,6 +8,24 @@ import kotlin.test.assertTrue
 
 class PeerProtocolStateTest {
   @Test
+  fun chokeRetryAcceptsOneResponseAndIgnoresItsLateDuplicate() {
+    val state = PeerProtocolState(1, maxPending = 1)
+    val request = PeerMessage.Request(0, 0, 16)
+    val response = PeerMessage.Piece(0, 0, ByteArray(16))
+    state.received(PeerMessage.Have(0))
+    state.received(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+    state.requested(request)
+    state.received(PeerMessage.Control(PeerMessage.Signal.CHOKE))
+    state.received(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+    state.requested(request)
+    assertTrue(state.received(response))
+    assertFalse(state.received(response))
+    assertFailsWith<IllegalArgumentException> {
+      state.received(PeerMessage.Piece(0, 16, ByteArray(16)))
+    }
+  }
+
+  @Test
   fun request_enforcesChokingAvailabilityAndPipeline() {
     val state = PeerProtocolState(2, maxPending = 1)
     val first = PeerMessage.Request(0, 0, 16)

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloaderTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloaderTest.kt
@@ -1,6 +1,9 @@
 package com.linroid.ketch.torrent
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import okio.Buffer
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
@@ -16,6 +19,46 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TorrentPeerDownloaderTest {
+  @Test
+  fun keepaliveChatterCannotExtendPayloadDeadline() = runTest {
+    val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+      "name" to "file", "piece length" to 1L, "length" to 1L,
+      "pieces" to sha1Digest(byteArrayOf(1))
+    ))))
+    val input = Buffer()
+      .write(PeerWire.encodeHandshake(PeerHandshake(metadata.infoHash, ByteArray(20), false, false)))
+      .write(PeerWire.encode(PeerMessage.Have(0)))
+      .write(PeerWire.encode(PeerMessage.Control(PeerMessage.Signal.UNCHOKE)))
+    var closed = false
+    val connection = object : TorrentConnection {
+      override val remote = PeerEndpoint("127.0.0.1", 1)
+      override suspend fun readExactly(size: Int): ByteArray {
+        if (input.size > 0) return input.readByteArray(size.toLong())
+        if (size > 0) delay(1_000)
+        return ByteArray(size)
+      }
+      override suspend fun write(bytes: ByteArray) = Unit
+      override fun close() { closed = true }
+    }
+    val delegate = createTorrentNetwork()
+    val network = object : TorrentNetwork by delegate {
+      override suspend fun connect(remote: PeerEndpoint) = connection
+    }
+    val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+      "ketch-chatter-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+    try {
+      val store = TorrentPieceStore(metadata, root / "file", emptySet(), "test")
+      val downloader = TorrentPeerDownloader(store, network, timeSource = testScheduler.timeSource)
+      assertFailsWith<TimeoutCancellationException> { downloader.download(connection.remote) }
+      assertEquals(30_000L, testScheduler.currentTime)
+      assertTrue(closed)
+      assertFalse(store.completed())
+    } finally {
+      delegate.close()
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+
   @Test
   fun download_selectedFilesAcrossPieceBoundaries_areVerified() = runTest {
     transfer(corrupt = false)

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloaderTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPeerDownloaderTest.kt
@@ -1,0 +1,98 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TorrentPeerDownloaderTest {
+  @Test
+  fun download_selectedFilesAcrossPieceBoundaries_areVerified() = runTest {
+    transfer(corrupt = false)
+  }
+
+  @Test
+  fun download_corruptPeer_doesNotReportOrPersistProgress() = runTest {
+    transfer(corrupt = true)
+  }
+
+  private suspend fun transfer(corrupt: Boolean) = withContext(Dispatchers.Default) {
+    withTimeout(15_000) {
+      coroutineScope {
+        val bytes = ByteArray(40_001) { (it * 13).toByte() }
+        val hashes = bytes.asList().chunked(20_000)
+          .fold(ByteArray(0)) { result, chunk -> result + sha1Digest(chunk.toByteArray()) }
+        val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+          "name" to "pack", "piece length" to 20_000L, "pieces" to hashes,
+          "files" to listOf(
+            mapOf("length" to 17_000L, "path" to listOf("first")),
+            mapOf("length" to 1_000L, "path" to listOf("skip")),
+            mapOf("length" to 22_001L, "path" to listOf("last"))
+          )
+        ))))
+        val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+          "ketch-transfer-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+        val network = createTorrentNetwork()
+        val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+        val store = TorrentPieceStore(metadata, root / "pack", setOf(0, 2), "test")
+        val server = async {
+          val connection = listener.accept()
+          try {
+            val wire = PeerWire(connection, metadata)
+            wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+            wire.send(PeerMessage.Bitfield(pieceBitfield(BooleanArray(3) { true })))
+            wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+            var sent = 0
+            while (sent < bytes.size) {
+              val request = wire.read()
+              if (request is PeerMessage.Request) {
+                val start = request.index * 20_000 + request.begin
+                val block = bytes.copyOfRange(start, start + request.length)
+                if (corrupt) block[0] = (block[0].toInt() xor 1).toByte()
+                wire.send(PeerMessage.Piece(request.index, request.begin, block))
+                sent += block.size
+                if (corrupt && sent == 20_000) break
+              }
+            }
+          } finally {
+            connection.close()
+          }
+        }
+        var progress = 0L
+        val downloader = TorrentPeerDownloader(store, network, onProgress = { progress = it })
+        try {
+          if (corrupt) {
+            assertFailsWith<IllegalArgumentException> { downloader.download(listener.local) }
+            assertEquals(0L, progress)
+            assertFalse(store.completed())
+            assertContentEquals(booleanArrayOf(false, false, false), store.verifiedPieces())
+          } else {
+            downloader.download(listener.local)
+            assertEquals(39_001L, progress)
+            assertTrue(store.completed())
+            assertContentEquals(bytes.copyOfRange(0, 17_000),
+              torrentFileSystem.read(root / "pack/first") { readByteArray() })
+            assertContentEquals(bytes.copyOfRange(18_000, bytes.size),
+              torrentFileSystem.read(root / "pack/last") { readByteArray() })
+            assertFalse(torrentFileSystem.exists(root / "pack/skip"))
+          }
+          server.await()
+        } finally {
+          network.close()
+          server.cancelAndJoin()
+          torrentFileSystem.deleteRecursively(root, mustExist = false)
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
+++ b/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
@@ -1,0 +1,74 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.Path.Companion.toPath
+import org.libtorrent4j.SessionManager
+import org.libtorrent4j.SessionParams
+import org.libtorrent4j.SettingsPack
+import org.libtorrent4j.TorrentInfo
+import org.libtorrent4j.swig.settings_pack
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** libtorrent is used only as an independent local reference seeder for this test. */
+class IndependentSeederTest {
+  @Test
+  fun kotlinDownloader_completesVerifiedTransferFromIndependentSeeder() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(20_000) {
+        NativeLibraryLoader.ensureLoaded()
+        val root = Files.createTempDirectory("ketch-interop").toFile()
+        val seed = root.resolve("seed").apply { mkdirs() }
+        val payload = ByteArray(80_037) { (it * 31 + 17).toByte() }
+        seed.resolve("fixture.bin").writeBytes(payload)
+        val hashes = payload.asList().chunked(16_384)
+          .fold(ByteArray(0)) { bytes, chunk -> bytes + sha1Digest(chunk.toByteArray()) }
+        val data = Bencode.encode(mapOf("info" to mapOf(
+          "name" to "fixture.bin", "length" to payload.size.toLong(),
+          "piece length" to 16_384L, "pieces" to hashes
+        )))
+        val settings = SettingsPack()
+        settings.setString(settings_pack.string_types.listen_interfaces.swigValue(), "127.0.0.1:0")
+        for (flag in listOf(settings_pack.bool_types.enable_dht, settings_pack.bool_types.enable_lsd,
+          settings_pack.bool_types.enable_upnp, settings_pack.bool_types.enable_natpmp)) {
+          settings.setBoolean(flag.swigValue(), false)
+        }
+        val manager = SessionManager()
+        val network = createTorrentNetwork()
+        try {
+          manager.start(SessionParams(settings))
+          val info = TorrentInfo(data)
+          manager.download(info, seed)
+          while (manager.find(info.infoHash())?.status()?.isSeeding() != true ||
+            manager.swig().listen_port() == 0) {
+            delay(20)
+          }
+          val output = root.resolve("download/fixture.bin")
+          val metadata = TorrentMetadata.fromBencode(data)
+          val store = TorrentPieceStore(metadata, output.absolutePath.toPath(), emptySet(), "interop")
+          var received = 0L
+          val progress = mutableListOf<Long>()
+          TorrentPeerDownloader(store, network, consumePayload = { received += it },
+            onProgress = { progress.add(it) }).download(
+            PeerEndpoint("127.0.0.1", manager.swig().listen_port())
+          )
+          assertContentEquals(payload, output.readBytes())
+          assertEquals(payload.size.toLong(), received)
+          assertEquals(payload.size.toLong(), progress.last())
+          assertTrue(store.completed())
+        } finally {
+          network.close()
+          manager.stop()
+          root.deleteRecursively()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the first pure Kotlin peer-to-file transfer path: TCP handshake, availability and choke handling, bounded block requests, SHA-1 verification, selected file writes, and verified progress. Completion tolerates the seeder closing after its final block.

Validation: JVM interoperability transfers 80,037 bytes from an independent libtorrent reference seeder with exact output verification. Common loopback tests cover multi-block pieces, selected files spanning skipped bytes, immediate peer close, and corrupt data on JVM, Android host, and iOS simulator. All torrent tests pass on those platforms.

Layer 6 of the approved stack, based on #152. This transfer primitive is assembled into the multi-peer runtime in subsequent layers; the existing product engine remains the default. The reference seeder is test-only usage of the current dependency and will be isolated from product dependencies at the removal gate.
