### PR TITLE
feat(torrent): HTTP and UDP tracker discovery and lifecycle

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -10,8 +10,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 03 Portable I/O | https://github.com/linroid/Ketch/pull/149 | Draft; real IPv4/IPv6 TCP/UDP and filesystem tests passed on JVM/Android/iOS |
 | 04 Peer wire/state | https://github.com/linroid/Ketch/pull/150 | Draft; local JVM/Android/iOS gates passed |
 | 05 Verified storage | https://github.com/linroid/Ketch/pull/152 | Draft; local JVM/Android/iOS gates passed |
-| 06 First verified transfer | Pending PR | JVM independent libtorrent seeder passed; JVM/Android/iOS loopback transfer and corruption gates passed |
-| 07–14 | Pending | Not implemented yet |
+| 06 First verified transfer | https://github.com/linroid/Ketch/pull/153 | JVM independent libtorrent seeder passed; JVM/Android/iOS loopback transfer and corruption gates passed |
+| 07 Tracker discovery | Pending PR | Local HTTP parsing, IPv4/IPv6 UDP, tier and lifecycle validation |
+| 08–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,6 +69,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }

--- a/library/ktor/src/commonMain/kotlin/com/linroid/ketch/engine/KtorHttpEngine.kt
+++ b/library/ktor/src/commonMain/kotlin/com/linroid/ketch/engine/KtorHttpEngine.kt
@@ -25,20 +25,22 @@ import kotlin.coroutines.cancellation.CancellationException
  *
  * @param client the Ktor HTTP client to use, or a default client
  *   with infinite timeouts (suitable for large downloads)
+ * @param logRequests whether request URLs, response headers, and transport errors may be logged
  */
 class KtorHttpEngine(
   private val client: HttpClient = defaultClient(),
+  private val logRequests: Boolean = true,
 ) : HttpEngine {
   private val log = KetchLogger("KtorHttpEngine")
 
   override suspend fun head(url: String, headers: Map<String, String>): ServerInfo {
     try {
-      log.d { "HEAD request: $url" }
+      if (logRequests) log.d { "HEAD request: $url" }
       val response = client.head(url) {
         headers.forEach { (name, value) -> header(name, value) }
       }
 
-      log.d {
+      if (logRequests) log.d {
         "HEAD ${response.status.value} headers: " +
           response.headers.entries().joinToString { (k, v) ->
             "$k=${v.joinToString(",")}"
@@ -46,7 +48,7 @@ class KtorHttpEngine(
       }
 
       if (!response.status.isSuccess()) {
-        log.e { "HTTP error ${response.status.value}: ${response.status.description}" }
+        if (logRequests) log.e { "HTTP error ${response.status.value}: ${response.status.description}" }
         val is429 = response.status.value == 429
         val retryAfter = if (is429) {
           parseRetryAfter(response.headers["Retry-After"])
@@ -56,7 +58,7 @@ class KtorHttpEngine(
           findRateLimitRemaining(response.headers)
         } else null
         if (is429) {
-          log.d {
+          if (logRequests) log.d {
             "Rate limit headers: retryAfter=$retryAfter, " +
               "remaining=$remaining"
           }
@@ -94,7 +96,7 @@ class KtorHttpEngine(
     } catch (e: KetchError) {
       throw e
     } catch (e: Exception) {
-      log.e { "Network error: ${e.message}" }
+      if (logRequests) log.e { "Network error: ${e.message}" }
       throw KetchError.Network(e)
     }
   }
@@ -107,9 +109,9 @@ class KtorHttpEngine(
   ) {
     try {
       if (range != null) {
-        log.d { "GET request: $url, range=${range.first}-${range.last}" }
+        if (logRequests) log.d { "GET request: $url, range=${range.first}-${range.last}" }
       } else {
-        log.d { "GET request: $url (no range)" }
+        if (logRequests) log.d { "GET request: $url (no range)" }
       }
       val customHeaders = headers
       client.prepareGet(url) {
@@ -120,7 +122,7 @@ class KtorHttpEngine(
       }.execute { response ->
         val status = response.status
 
-        log.d {
+        if (logRequests) log.d {
           "GET ${status.value} headers: " +
             response.headers.entries().joinToString { (k, v) ->
               "$k=${v.joinToString(",")}"
@@ -128,7 +130,7 @@ class KtorHttpEngine(
         }
 
         if (!status.isSuccess()) {
-          log.e { "HTTP error ${status.value}: ${status.description}" }
+          if (logRequests) log.e { "HTTP error ${status.value}: ${status.description}" }
           val is429 = status.value == 429
           val retryAfter = if (is429) {
             parseRetryAfter(response.headers["Retry-After"])
@@ -138,7 +140,7 @@ class KtorHttpEngine(
             findRateLimitRemaining(response.headers)
           } else null
           if (is429) {
-            log.d {
+            if (logRequests) log.d {
               "Rate limit headers: retryAfter=$retryAfter, " +
                 "remaining=$remaining"
             }
@@ -164,7 +166,7 @@ class KtorHttpEngine(
     } catch (e: KetchError) {
       throw e
     } catch (e: Exception) {
-      log.e { "Network error: ${e.message}" }
+      if (logRequests) log.e { "Network error: ${e.message}" }
       throw KetchError.Network(e)
     }
   }

--- a/library/torrent/build.gradle.kts
+++ b/library/torrent/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
       api(projects.library.core)
       implementation(libs.okio)
       implementation(libs.ktor.network)
+      implementation(libs.ktor.http)
       implementation(projects.library.ktor)
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.kotlinx.serialization.json)

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentHttp.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentHttp.kt
@@ -33,6 +33,6 @@ internal class TorrentHttp(
   }
 
   companion object {
-    fun default(): TorrentHttp = TorrentHttp(KtorHttpEngine(), ownsEngine = true)
+    fun default(): TorrentHttp = TorrentHttp(KtorHttpEngine(logRequests = false), ownsEngine = true)
   }
 }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentTracker.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentTracker.kt
@@ -1,0 +1,239 @@
+package com.linroid.ketch.torrent
+
+import io.ktor.http.Url
+import io.ktor.network.sockets.InetSocketAddress
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.Buffer
+import kotlin.coroutines.cancellation.CancellationException
+
+internal enum class TrackerEvent(val code: Int) {
+  NONE(0), COMPLETED(1), STARTED(2), STOPPED(3)
+}
+
+internal data class TrackerAnnounce(
+  val infoHash: InfoHash,
+  val peerId: ByteArray,
+  val port: Int,
+  val downloaded: Long,
+  val left: Long,
+  val uploaded: Long = 0,
+  val event: TrackerEvent = TrackerEvent.NONE,
+  val key: Int = 0,
+) {
+  init {
+    require(peerId.size == 20 && port in 1..65535)
+    require(downloaded >= 0 && left >= 0 && uploaded >= 0)
+  }
+}
+
+internal data class TrackerResponse(
+  val peers: List<PeerEndpoint>,
+  val intervalSeconds: Long,
+  val trackerId: ByteArray? = null,
+  val source: String? = null,
+)
+
+/** BEP 3/15/41 tracker exchange. Error messages deliberately exclude URLs and tracker text. */
+internal class TorrentTracker(
+  private val http: TorrentHttp,
+  private val network: TorrentNetwork,
+  private val resolve: suspend (PeerEndpoint) -> PeerEndpoint = { endpoint ->
+    withContext(Dispatchers.IO) {
+      PeerEndpoint(numericHost(checkNotNull(
+        InetSocketAddress(endpoint.host, endpoint.port).resolveAddress()
+      )), endpoint.port)
+    }
+  },
+  private val retryDelaysMs: List<Long> = listOf(15_000, 30_000, 60_000),
+) {
+  init {
+    require(retryDelaysMs.isNotEmpty() && retryDelaysMs.size <= 9)
+    require(retryDelaysMs.all { it in 1..3_840_000 })
+  }
+
+  suspend fun announce(
+    url: String,
+    request: TrackerAnnounce,
+    trackerId: ByteArray? = null,
+  ): TrackerResponse {
+    require(url.length <= 8192)
+    val parsed = Url(url)
+    return when (parsed.protocol.name.lowercase()) {
+      "http", "https" -> parseHttp(http.fetch(httpUrl(url, request, trackerId), 1024 * 1024))
+      "udp" -> udp(parsed, request)
+      else -> error("Unsupported tracker protocol")
+    }
+  }
+
+  private suspend fun udp(url: Url, request: TrackerAnnounce): TrackerResponse {
+    require(url.port in 1..65535 && url.user == null && url.password == null)
+    val remote = resolve(PeerEndpoint(url.host.removeSurrounding("[", "]"), url.port))
+    val socket = network.bindUdp(PeerEndpoint(if (':' in remote.host) "::" else "0.0.0.0", 0))
+    try {
+      // Each retry obtains a new connection ID, so expired cookies are never reused.
+      for (timeout in retryDelaysMs) {
+        val result = withTimeoutOrNull(timeout) {
+          val connectId = randomInt()
+          val connect = Buffer().writeLong(0x41727101980L).writeInt(0).writeInt(connectId)
+          socket.send(remote, connect.readByteArray())
+          val connected = response(socket, remote, connectId, 0, 16)
+          val cookie = Buffer().write(connected, 8, 8).readLong()
+          val transaction = randomInt()
+          val packet = Buffer().writeLong(cookie).writeInt(1).writeInt(transaction)
+            .write(request.infoHash.toBytes()).write(request.peerId)
+            .writeLong(request.downloaded).writeLong(request.left).writeLong(request.uploaded)
+            .writeInt(request.event.code).writeInt(0).writeInt(request.key).writeInt(200)
+            .writeShort(request.port)
+          val path = url.encodedPathAndQuery.encodeToByteArray()
+          if (path.isNotEmpty() && !path.contentEquals(byteArrayOf('/'.code.toByte()))) {
+            var offset = 0
+            while (offset < path.size) {
+              val length = minOf(255, path.size - offset)
+              packet.writeByte(2).writeByte(length).write(path, offset, length)
+              offset += length
+            }
+            packet.writeByte(0)
+          }
+          socket.send(remote, packet.readByteArray())
+          val reply = response(socket, remote, transaction, 1, 20)
+          val header = Buffer().write(reply, 8, 12)
+          val interval = header.readInt().toLong() and 0xffffffffL
+          TrackerResponse(compactPeers(reply.copyOfRange(20, reply.size), ':' in remote.host),
+            checkedInterval(interval))
+        }
+        if (result != null) return result
+      }
+      error("Tracker did not respond")
+    } finally {
+      socket.close()
+    }
+  }
+
+  private suspend fun response(
+    socket: TorrentDatagramSocket,
+    remote: PeerEndpoint,
+    transaction: Int,
+    action: Int,
+    minimum: Int,
+  ): ByteArray {
+    while (true) {
+      currentCoroutineContext().ensureActive()
+      val reply = socket.receive()
+      if (reply.remote != remote || reply.bytes.size < 8) continue
+      val header = Buffer().write(reply.bytes, 0, 8)
+      val receivedAction = header.readInt()
+      if (header.readInt() != transaction) continue
+      require(receivedAction != 3) { "Tracker rejected announce" }
+      if (receivedAction != action || reply.bytes.size < minimum) continue
+      return reply.bytes
+    }
+  }
+
+  companion object {
+    fun httpUrl(url: String, request: TrackerAnnounce, trackerId: ByteArray?): String {
+      val base = url.substringBefore('#')
+      val separator = if ('?' in base) "&" else "?"
+      return buildString {
+        append(base).append(separator)
+        append("info_hash=").append(binaryQuery(request.infoHash.toBytes()))
+        append("&peer_id=").append(binaryQuery(request.peerId))
+        append("&port=").append(request.port)
+        append("&downloaded=").append(request.downloaded)
+        append("&left=").append(request.left)
+        append("&uploaded=").append(request.uploaded)
+        append("&compact=1&numwant=200&key=").append(request.key.toUInt())
+        if (request.event != TrackerEvent.NONE) {
+          append("&event=").append(request.event.name.lowercase())
+        }
+        if (trackerId != null) append("&trackerid=").append(binaryQuery(trackerId))
+      }
+    }
+
+    fun parseHttp(bytes: ByteArray): TrackerResponse {
+      val root = Bencode.parse(bytes, 1024 * 1024)
+      require(root.dictionary != null && root["failure reason"] == null) {
+        "Tracker rejected announce"
+      }
+      val interval = checkedInterval(requireNotNull(root["interval"]?.integer))
+      val minimum = root["min interval"]?.integer ?: interval
+      require(minimum in 1..604_800)
+      val peers = mutableListOf<PeerEndpoint>()
+      root["peers"]?.let { node ->
+        if (node.bytes != null) peers += compactPeers(node.bytes!!, false)
+        else {
+          val list = requireNotNull(node.list)
+          require(list.size <= 4096)
+          for (item in list) {
+            val host = requireNotNull(item["ip"]?.text())
+            val port = requireNotNull(item["port"]?.integer)
+            require(port in 1..65535)
+            peers += PeerEndpoint(host, port.toInt())
+          }
+        }
+      }
+      root["peers6"]?.let { peers += compactPeers(requireNotNull(it.bytes), true) }
+      val id = root["tracker id"]?.bytes
+      require(id == null || id.size <= 1024)
+      return TrackerResponse(peers.distinct().take(4096), maxOf(interval, minimum), id)
+    }
+
+    fun compactPeers(bytes: ByteArray, ipv6: Boolean): List<PeerEndpoint> {
+      val stride = if (ipv6) 18 else 6
+      require(bytes.size % stride == 0 && bytes.size / stride <= 4096)
+      return bytes.indices.step(stride).mapNotNull { offset ->
+        val port = ((bytes[offset + stride - 2].toInt() and 255) shl 8) or
+          (bytes[offset + stride - 1].toInt() and 255)
+        if (port == 0) null else PeerEndpoint(
+          numericHost(bytes.copyOfRange(offset, offset + stride - 2)), port
+        )
+      }.distinct()
+    }
+
+    private fun checkedInterval(value: Long): Long {
+      require(value in 1..604_800) { "Invalid tracker interval" }
+      return value
+    }
+
+    private fun randomInt(): Int = Buffer().write(torrentRandomBytes(4)).readInt()
+
+    private fun binaryQuery(bytes: ByteArray): String = bytes.joinToString("") {
+      "%" + (it.toInt() and 255).toString(16).padStart(2, '0')
+    }
+  }
+}
+
+/** BEP 12: exhaust a tier before falling back; promote a successful tracker within its tier. */
+internal class TrackerTiers(
+  tiers: List<List<String>>,
+  private val announce: suspend (String, TrackerAnnounce, ByteArray?) -> TrackerResponse,
+) {
+  private val tiers = tiers.map { it.distinct().shuffled().toMutableList() }
+  private val ids = mutableMapOf<String, ByteArray>()
+
+  suspend fun announce(request: TrackerAnnounce): TrackerResponse {
+    for (tier in tiers) {
+      for (url in tier.toList()) {
+        try {
+          val result = announce(url, request, ids[url])
+          result.trackerId?.let { ids[url] = it }
+          tier.remove(url)
+          tier.add(0, url)
+          return result.copy(source = url)
+        } catch (_: TimeoutCancellationException) {
+          currentCoroutineContext().ensureActive()
+        } catch (e: CancellationException) {
+          throw e
+        } catch (_: Exception) {
+          currentCoroutineContext().ensureActive()
+        }
+      }
+    }
+    error("No tracker responded")
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TrackerDiscovery.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TrackerDiscovery.kt
@@ -1,0 +1,57 @@
+package com.linroid.ketch.torrent
+
+import kotlin.time.TimeSource
+
+/** Serialized per-session tracker lifecycle; callers supply whole-torrent verified state. */
+internal class TrackerDiscovery(
+  private val metadata: TorrentMetadata,
+  private val peerId: ByteArray,
+  private val port: Int,
+  private val trackers: TrackerTiers,
+  private val onPrivateTrackerChanged: suspend () -> Unit = {},
+  private val nowMs: () -> Long = monotonicClock(),
+) {
+  private var nextAnnounce = 0L
+  private var started = false
+  private var completed = false
+  private var source: String? = null
+  private val key = okio.Buffer().write(torrentRandomBytes(4)).readInt()
+
+  suspend fun poll(
+    verified: BooleanArray,
+    downloaded: Long,
+    uploaded: Long,
+    stopped: Boolean = false,
+  ): TrackerResponse? {
+    require(verified.size == metadata.pieceHashes.size / 20)
+    val left = verified.indices.sumOf { index ->
+      if (verified[index]) 0L else minOf(metadata.pieceLength,
+        metadata.totalBytes - index.toLong() * metadata.pieceLength)
+    }
+    val event = when {
+      stopped && started -> TrackerEvent.STOPPED
+      stopped -> return null
+      !started -> TrackerEvent.STARTED
+      left == 0L && !completed -> TrackerEvent.COMPLETED
+      else -> TrackerEvent.NONE
+    }
+    if (event == TrackerEvent.NONE && nowMs() < nextAnnounce) return null
+    val result = trackers.announce(TrackerAnnounce(metadata.infoHash, peerId, port, downloaded,
+      left, uploaded, event, key))
+    if (metadata.isPrivate && source != null && source != result.source) {
+      onPrivateTrackerChanged()
+    }
+    source = result.source
+    started = event != TrackerEvent.STOPPED
+    if (event == TrackerEvent.COMPLETED || (event == TrackerEvent.STARTED && left == 0L)) {
+      completed = true
+    }
+    nextAnnounce = nowMs() + result.intervalSeconds * 1000
+    return result
+  }
+}
+
+internal fun monotonicClock(): () -> Long {
+  val origin = TimeSource.Monotonic.markNow()
+  return { origin.elapsedNow().inWholeMilliseconds }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentTrackerTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentTrackerTest.kt
@@ -1,0 +1,137 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class TorrentTrackerTest {
+  private val request = TrackerAnnounce(InfoHash.fromBytes(ByteArray(20) { it.toByte() }),
+    ByteArray(20) { (255 - it).toByte() }, 6881, 123, 456, event = TrackerEvent.STARTED)
+
+  @Test
+  fun httpQuery_preservesPasskeyAndEncodesBinaryWithoutUtf8Conversion() {
+    val url = TorrentTracker.httpUrl("https://tracker/secret?passkey=a%2Bb", request,
+      byteArrayOf(0, 255.toByte(), 32))
+    assertTrue(url.startsWith("https://tracker/secret?passkey=a%2Bb&info_hash=%00%01%02"))
+    assertTrue("peer_id=%ff%fe%fd" in url)
+    assertTrue("&event=started&trackerid=%00%ff%20" in url)
+    assertTrue("&downloaded=123&left=456&uploaded=0" in url)
+  }
+
+  @Test
+  fun httpResponse_readsBothFamiliesAndMinimumInterval() {
+    val response = TorrentTracker.parseHttp(Bencode.encode(mapOf(
+      "interval" to 30L, "min interval" to 60L,
+      "peers" to byteArrayOf(127, 0, 0, 1, 0x1a, 0xe1.toByte()),
+      "peers6" to (ByteArray(15) + byteArrayOf(1, 0x1a, 0xe1.toByte()))
+    )))
+    assertEquals(60L, response.intervalSeconds)
+    assertEquals(listOf(PeerEndpoint("127.0.0.1", 6881),
+      PeerEndpoint("0:0:0:0:0:0:0:1", 6881)), response.peers)
+    assertFailsWith<IllegalArgumentException> {
+      TorrentTracker.compactPeers(byteArrayOf(1), false)
+    }
+    val error = assertFailsWith<IllegalArgumentException> {
+      TorrentTracker.parseHttp(Bencode.encode(mapOf("failure reason" to "secret passkey")))
+    }
+    assertEquals("Tracker rejected announce", error.message)
+  }
+
+  @Test
+  fun tiers_exhaustFailedTierAndRememberSuccessfulTrackerId() = runTest {
+    val calls = mutableListOf<String>()
+    val tracker = TrackerTiers(listOf(listOf("a", "b"), listOf("c"))) { url, _, id ->
+      calls += url
+      if (url != "c") error("offline")
+      if (calls.size > 3) assertContentEquals(byteArrayOf(7), id)
+      TrackerResponse(emptyList(), 60, byteArrayOf(7))
+    }
+    tracker.announce(request)
+    assertEquals(setOf("a", "b"), calls.take(2).toSet())
+    assertEquals("c", calls.last())
+    tracker.announce(request)
+    assertEquals(6, calls.size)
+  }
+
+  @Test
+  fun udp_ipv4_validatesTransactionAndCarriesAnnounceFields() = runTest { udp(false) }
+
+  @Test
+  fun udp_ipv6_validatesTransactionAndCarriesAnnounceFields() = runTest { udp(true) }
+
+  @Test
+  fun udp_lostConnectResponse_retriesAndIgnoresSpoofedEndpoint() = runTest {
+    udp(false, dropFirst = true)
+  }
+
+  private suspend fun udp(ipv6: Boolean, dropFirst: Boolean = false) = withContext(Dispatchers.Default) {
+    withTimeout(15_000) {
+      coroutineScope {
+        val network = createTorrentNetwork()
+        val http = TorrentHttp.default()
+        val socket = network.bindUdp(PeerEndpoint(if (ipv6) "::1" else "127.0.0.1", 0))
+        try {
+          val server = async {
+            if (dropFirst) socket.receive()
+            val connect = socket.receive()
+            val packet = Buffer().write(connect.bytes)
+            assertEquals(0x41727101980L, packet.readLong())
+            assertEquals(0, packet.readInt())
+            val id = packet.readInt()
+            val spoofer = network.bindUdp(PeerEndpoint(if (ipv6) "::1" else "127.0.0.1", 0))
+            try {
+              spoofer.send(connect.remote, Buffer().writeInt(3).writeInt(id).readByteArray())
+            } finally {
+              spoofer.close()
+            }
+            socket.send(connect.remote, Buffer().writeInt(0).writeInt(id xor 1)
+              .writeLong(99).readByteArray())
+            socket.send(connect.remote, Buffer().writeInt(0).writeInt(id)
+              .writeLong(99).readByteArray())
+            val announce = socket.receive()
+            val body = Buffer().write(announce.bytes)
+            assertEquals(99L, body.readLong())
+            assertEquals(1, body.readInt())
+            val transaction = body.readInt()
+            assertContentEquals(request.infoHash.toBytes(), body.readByteArray(20))
+            assertContentEquals(request.peerId, body.readByteArray(20))
+            assertEquals(123L, body.readLong())
+            assertEquals(456L, body.readLong())
+            assertEquals(0L, body.readLong())
+            assertEquals(2, body.readInt())
+            body.skip(12)
+            assertEquals(6881, body.readShort().toInt() and 65535)
+            assertEquals(2, body.readByte().toInt())
+            val length = body.readByte().toInt() and 255
+            assertEquals("/announce?key=a%2Bb", body.readUtf8(length.toLong()))
+            val address = if (ipv6) ByteArray(15) + byteArrayOf(1)
+              else byteArrayOf(127, 0, 0, 1)
+            socket.send(announce.remote, Buffer().writeInt(1).writeInt(transaction)
+              .writeInt(60).writeInt(0).writeInt(1).write(address).writeShort(6881)
+              .readByteArray())
+          }
+          val host = if (ipv6) "[::1]" else "127.0.0.1"
+          val response = TorrentTracker(http, network,
+            retryDelaysMs = if (dropFirst) listOf(100, 5000) else listOf(5000)).announce(
+            "udp://$host:${socket.local.port}/announce?key=a%2Bb", request
+          )
+          assertEquals(60L, response.intervalSeconds)
+          assertEquals(6881, response.peers.single().port)
+          server.await()
+        } finally {
+          network.close()
+          http.close()
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TrackerDiscoveryTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TrackerDiscoveryTest.kt
@@ -1,0 +1,59 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class TrackerDiscoveryTest {
+  @Test
+  fun selectionCompletion_keepsWholeTorrentLeftAndHonorsInterval() = runTest {
+    val metadata = metadata()
+    var now = 0L
+    val requests = mutableListOf<TrackerAnnounce>()
+    val tiers = TrackerTiers(listOf(listOf("a"))) { _, request, _ ->
+      requests += request
+      TrackerResponse(emptyList(), 60)
+    }
+    val discovery = TrackerDiscovery(metadata, ByteArray(20), 6881, tiers, nowMs = { now })
+    val verified = booleanArrayOf(true, false)
+    assertNotNull(discovery.poll(verified, 20, 0))
+    assertEquals(TrackerEvent.STARTED, requests.last().event)
+    assertEquals(3L, requests.last().left)
+    assertNull(discovery.poll(verified, 20, 0))
+    now = 60_000
+    discovery.poll(verified, 20, 0)
+    assertEquals(TrackerEvent.NONE, requests.last().event)
+    discovery.poll(booleanArrayOf(true, true), 23, 0)
+    assertEquals(TrackerEvent.COMPLETED, requests.last().event)
+    assertEquals(0L, requests.last().left)
+    discovery.poll(booleanArrayOf(true, true), 23, 0, stopped = true)
+    assertEquals(TrackerEvent.STOPPED, requests.last().event)
+  }
+
+  @Test
+  fun privateTrackerSwitch_dropsPriorPeersBeforeReturningNewPeers() = runTest {
+    var firstOnline = true
+    val tiers = TrackerTiers(listOf(listOf("a"), listOf("b"))) { url, _, _ ->
+      if (url == "a" && !firstOnline) error("offline")
+      TrackerResponse(listOf(PeerEndpoint("127.0.0.1", 6881)), 1)
+    }
+    var drops = 0
+    var now = 0L
+    val discovery = TrackerDiscovery(metadata(), ByteArray(20), 6881, tiers,
+      onPrivateTrackerChanged = { drops++ }, nowMs = { now })
+    discovery.poll(booleanArrayOf(false, false), 0, 0)
+    assertEquals(0, drops)
+    firstOnline = false
+    now = 1000
+    assertEquals("b", discovery.poll(booleanArrayOf(false, false), 0, 0)?.source)
+    assertEquals(1, drops)
+  }
+
+  private fun metadata(): TorrentMetadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf(
+    "info" to mapOf("name" to "test", "length" to 7L, "piece length" to 4L,
+      "pieces" to (sha1Digest(byteArrayOf(1, 2, 3, 4)) + sha1Digest(byteArrayOf(5, 6, 7))),
+      "private" to 1L)
+  )))
+}


### PR DESCRIPTION
Adds common Kotlin HTTP(S)/UDP tracker discovery, binary query encoding, compact/dictionary IPv4/IPv6 peers, tier failover, tracker IDs, bounded responses, and BEP 41 URL data. UDP exchanges check source endpoint, transaction and action, retry lost responses, and refresh connection cookies on retries.

A per-session lifecycle tracks announce intervals, whole-torrent remaining bytes, started/completed/stopped events, and private tracker changes. Completing a selected subset does not announce whole-torrent completion. The default torrent HTTP adapter suppresses request/header/error logging to protect tracker credentials.

Validation: all torrent tests pass on JVM, Android host, and iOS simulator. Local UDP fixtures cover both address families, lost responses and spoofed endpoints/transactions. Common tests cover HTTP encoding/parsing, tiers, minimum intervals, private switching and partial selection accounting. Runtime discovery and private-peer teardown are assembled with the engine in subsequent layers; actual TLS fixture validation remains an integration gate.

Layer 7 of the approved stack, based on #153.
