### PR TITLE
feat(torrent): bounded swarm scheduling and upload policies

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -11,8 +11,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 04 Peer wire/state | https://github.com/linroid/Ketch/pull/150 | Draft; local JVM/Android/iOS gates passed |
 | 05 Verified storage | https://github.com/linroid/Ketch/pull/152 | Draft; local JVM/Android/iOS gates passed |
 | 06 First verified transfer | https://github.com/linroid/Ketch/pull/153 | JVM independent libtorrent seeder passed; JVM/Android/iOS loopback transfer and corruption gates passed |
-| 07 Tracker discovery | Pending PR | Local HTTP parsing, IPv4/IPv6 UDP, tier and lifecycle validation |
-| 08–14 | Pending | Not implemented yet |
+| 07 Tracker discovery | https://github.com/linroid/Ketch/pull/154 | Local HTTP parsing, IPv4/IPv6 UDP, tier and lifecycle validation |
+| 08 Swarm and upload | Pending PR | Rarity/pipelines, complementary peers, recovery, upload policies and seeding lifecycle on JVM/Android/iOS |
+| 09–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPieceScheduler.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPieceScheduler.kt
@@ -1,0 +1,112 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/** Shared across sessions; reservations precede allocating piece and connection buffers. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class TorrentBufferBudget(val capacity: Int) {
+  private val used = AtomicInt(0)
+  val allocated: Int get() = used.load()
+
+  init { require(capacity > 0) }
+
+  inner class Lease(val bytes: Int) {
+    private val closed = AtomicBoolean(false)
+    fun close() {
+      if (closed.compareAndSet(false, true)) used.fetchAndAdd(-bytes)
+    }
+  }
+
+  fun reserve(bytes: Int): Lease? {
+    require(bytes > 0)
+    while (true) {
+      val current = used.load()
+      if (bytes > capacity - current) return null
+      if (used.compareAndSet(current, current + bytes)) return Lease(bytes)
+    }
+  }
+}
+
+/** Serialized rarity and ownership state. No disk or network operation runs under its lock. */
+internal class TorrentPieceScheduler(
+  private val wanted: BooleanArray,
+  verified: BooleanArray,
+  private val pieceSize: (Int) -> Int,
+  private val budget: TorrentBufferBudget,
+) {
+  private val mutex = Mutex()
+  private val verified = verified.copyOf()
+  private val availability = mutableMapOf<Int, BooleanArray>()
+  private var version = 0L
+  private val rarity = IntArray(wanted.size)
+  private val owners = mutableMapOf<Int, MutableSet<Int>>()
+  private val claims = mutableMapOf<Int, Claim>()
+
+  class Claim(val index: Int, val lease: TorrentBufferBudget.Lease) {
+    val bytes: ByteArray = ByteArray(lease.bytes)
+  }
+
+  init { require(wanted.size == verified.size) }
+
+  suspend fun availability(peer: Int, pieces: BooleanArray) = mutex.withLock {
+    require(pieces.size == wanted.size)
+    val previous = availability.put(peer, pieces.copyOf())
+    for (index in pieces.indices) {
+      if (previous?.get(index) == true) rarity[index]--
+      if (pieces[index]) rarity[index]++
+    }
+  }
+
+  suspend fun claim(peer: Int): Claim? = mutex.withLock {
+    check(peer !in claims)
+    val available = availability[peer] ?: return@withLock null
+    val candidates = wanted.indices.filter { wanted[it] && !verified[it] && available[it] }
+    val unclaimed = candidates.filter { owners[it].isNullOrEmpty() }
+    // Duplicate at most twice, only when remaining work is already assigned (endgame).
+    val choices = unclaimed.ifEmpty {
+      if (wanted.indices.count { wanted[it] && !verified[it] } > availability.size) emptyList()
+      else candidates.filter { (owners[it]?.size ?: 0) < 2 }
+    }
+    val index = choices.minWithOrNull(compareBy<Int> { rarity[it] }.thenBy { it })
+      ?: return@withLock null
+    val lease = budget.reserve(pieceSize(index)) ?: return@withLock null
+    val claim = try { Claim(index, lease) } catch (e: Throwable) { lease.close(); throw e }
+    owners.getOrPut(index) { mutableSetOf() }.add(peer)
+    claims[peer] = claim
+    claim
+  }
+
+  suspend fun isVerified(index: Int): Boolean = mutex.withLock { verified[index] }
+
+  suspend fun verified(index: Int) = mutex.withLock {
+    if (!verified[index]) {
+      verified[index] = true
+      version++
+    }
+  }
+
+  suspend fun snapshot(knownVersion: Long): Pair<Long, BooleanArray>? = mutex.withLock {
+    if (knownVersion == version) null else version to verified.copyOf()
+  }
+
+  suspend fun release(peer: Int) = mutex.withLock { releaseLocked(peer) }
+
+  suspend fun remove(peer: Int) = mutex.withLock {
+    releaseLocked(peer)
+    availability.remove(peer)?.forEachIndexed { index, present -> if (present) rarity[index]-- }
+  }
+
+  private fun releaseLocked(peer: Int) {
+    claims.remove(peer)?.let { claim ->
+      owners[claim.index]?.let { peers ->
+        peers.remove(peer)
+        if (peers.isEmpty()) owners.remove(claim.index)
+      }
+      claim.lease.close()
+    }
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -1,0 +1,319 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.IOException
+import kotlin.time.TimeSource
+
+/** Bounded peer workers around verified storage. Each worker owns its wire and request state. */
+internal class TorrentSwarm(
+  private val store: TorrentPieceStore,
+  private val network: TorrentNetwork,
+  private val budget: TorrentBufferBudget,
+  private val peerId: ByteArray = torrentRandomBytes(20),
+  private val connections: () -> Int = { 20 },
+  private val uploadPolicy: TorrentUploadPolicy = TorrentUploadPolicy.DISABLED,
+  private val downloadPayload: suspend (Int) -> Unit = {},
+  private val uploadPayload: suspend (Int) -> Unit = {},
+  private val onProgress: suspend (Long) -> Unit = {},
+  private val onCompleted: suspend () -> Unit = {},
+) {
+  private val uploadSlots = Semaphore(4)
+
+  /** A closed peer stream fails once every candidate has exhausted its bounded retries. */
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  suspend fun run(peers: ReceiveChannel<PeerEndpoint>) = supervisorScope {
+    store.initialize()
+    val scheduler = TorrentPieceScheduler(BooleanArray(store.pieceCount) { store.needed(it) },
+      store.verifiedPieces(), store::pieceSize, budget)
+    val largestPiece = (0 until store.pieceCount).filter { store.needed(it) }
+      .maxOfOrNull { store.pieceSize(it) } ?: 0
+    require(budget.capacity >= largestPiece + 256 * 1024 + store.pieceCount * 4) {
+      "Torrent buffer limit cannot hold a piece and peer protocol state"
+    }
+    val active = mutableMapOf<PeerEndpoint, Job>()
+    val attempts = linkedMapOf<PeerEndpoint, Int>()
+    val pending = ArrayDeque<PeerEndpoint>()
+    val results = Channel<Pair<PeerEndpoint, Throwable?>>(512)
+    val progressEvents = Channel<Unit>(Channel.CONFLATED)
+    val retryAt = mutableMapOf<PeerEndpoint, Long>()
+    val now = monotonicClock()
+    var discoveryClosed = false
+    var complete = false
+    var nextId = 0
+    try {
+      while (currentCoroutineContext().isActive) {
+        if (store.completed() && !complete) {
+          store.finish()
+          onProgress(store.progress().sum())
+          onCompleted()
+          complete = true
+        }
+        if (complete && uploadPolicy != TorrentUploadPolicy.SEED_AFTER_COMPLETION) break
+        val limit = connections().coerceIn(1, 512)
+        active.entries.drop(limit).forEach { it.value.cancel() }
+        var candidates = pending.size
+        while (active.size < limit && pending.isNotEmpty() && candidates-- > 0) {
+          val endpoint = pending.removeFirst()
+          if (endpoint in active) continue
+          if ((retryAt[endpoint] ?: 0) > now()) {
+            pending.addLast(endpoint)
+            continue
+          }
+          val overhead = budget.reserve(256 * 1024 + store.pieceCount * 4) ?: run {
+            pending.addFirst(endpoint)
+            break
+          }
+          val id = nextId++
+          attempts[endpoint] = (attempts[endpoint] ?: 0) + 1
+          active[endpoint] = launch(Dispatchers.Default) {
+            var failure: Throwable? = null
+            try {
+              peer(id, endpoint, scheduler, progressEvents)
+            } catch (e: CancellationException) {
+              throw e
+            } catch (e: Exception) {
+              failure = e
+            } finally {
+              withContext(NonCancellable) { scheduler.remove(id) }
+              overhead.close()
+              results.trySend(endpoint to failure)
+            }
+          }
+        }
+        if (discoveryClosed && pending.isEmpty() && active.isEmpty()) {
+          check(complete) { "No peer could complete the torrent" }
+          break
+        }
+        select<Unit> {
+          if (!discoveryClosed) peers.onReceiveCatching { result ->
+            val endpoint = result.getOrNull()
+            if (endpoint == null) discoveryClosed = true
+            else if (endpoint !in attempts && attempts.size + pending.size < 4096 &&
+              endpoint !in pending) pending.addLast(endpoint)
+          }
+          results.onReceive { (endpoint, failure) ->
+            active.remove(endpoint)
+            if (failure is TorrentStorageException) throw failure
+            if (failure !is IllegalArgumentException && (attempts[endpoint] ?: 0) < 3 &&
+              !complete) {
+              retryAt[endpoint] = now() + 1000L * (attempts[endpoint] ?: 1)
+              pending.addLast(endpoint)
+            }
+          }
+          progressEvents.onReceive { onProgress(store.progress().sum()) }
+          onTimeout(100) {}
+        }
+      }
+    } finally {
+      active.values.forEach { it.cancel() }
+      active.values.forEach { it.join() }
+      results.close()
+      progressEvents.close()
+    }
+  }
+
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  private suspend fun peer(
+    id: Int,
+    endpoint: PeerEndpoint,
+    scheduler: TorrentPieceScheduler,
+    progressEvents: SendChannel<Unit>,
+  ) =
+    supervisorScope {
+      val connection = network.connect(endpoint)
+      var uploadSlot = false
+      try {
+        val wire = PeerWire(connection, store.metadata, idleTimeoutMs = 60_000)
+        val handshake = wire.handshake(PeerHandshake(store.metadata.infoHash, peerId, false, false))
+        require(!handshake.peerId.contentEquals(peerId)) { "Connected to ourselves" }
+        val state = PeerProtocolState(store.pieceCount, maxPending = 16)
+        val advertised = store.verifiedPieces()
+        var version = -1L
+        wire.send(PeerMessage.Bitfield(pieceBitfield(advertised)))
+        wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
+        val messages = Channel<PeerMessage>(1)
+        val reader = launch {
+          try {
+            while (isActive) {
+              val message = wire.read()
+              if (message is PeerMessage.Piece) downloadPayload(message.bytes.size)
+              messages.send(message)
+            }
+          } catch (e: Throwable) {
+            messages.close(e)
+          }
+        }
+        var claim: TorrentPieceScheduler.Claim? = null
+        var received = BooleanArray(0)
+        var requested = BooleanArray(0)
+        var receivedBytes = 0
+        var lastBlock = TimeSource.Monotonic.markNow()
+        var lastWrite = TimeSource.Monotonic.markNow()
+        try {
+          while (isActive) {
+            val message = select<PeerMessage?> {
+              messages.onReceive { it }
+              onTimeout(100) { null }
+            }
+            if (message != null) {
+              val accepted = state.received(message)
+              when (message) {
+                is PeerMessage.Bitfield, is PeerMessage.Have ->
+                  scheduler.availability(id, state.available)
+                is PeerMessage.Control -> {
+                  if (message.signal == PeerMessage.Signal.CHOKE) {
+                    scheduler.release(id)
+                    claim = null
+                  }
+                  if (message.signal == PeerMessage.Signal.INTERESTED && !uploadSlot &&
+                    uploadPolicy != TorrentUploadPolicy.DISABLED && uploadSlots.tryAcquire()) {
+                    uploadSlot = true
+                    wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+                  }
+                  if (message.signal == PeerMessage.Signal.NOT_INTERESTED && uploadSlot) {
+                    uploadSlots.release()
+                    uploadSlot = false
+                    wire.send(PeerMessage.Control(PeerMessage.Signal.CHOKE))
+                  }
+                }
+                is PeerMessage.Piece -> if (accepted) {
+                  val current = checkNotNull(claim)
+                  check(message.index == current.index && message.begin % PeerWire.BLOCK_SIZE == 0)
+                  val block = message.begin / PeerWire.BLOCK_SIZE
+                  check(!received[block])
+                  message.bytes.copyInto(current.bytes, message.begin)
+                  received[block] = true
+                  receivedBytes += message.bytes.size
+                  lastBlock = TimeSource.Monotonic.markNow()
+                  if (receivedBytes == current.bytes.size) {
+                    val valid = storage { store.commit(current.index, current.bytes) }
+                    require(valid) { "Peer sent a corrupt piece" }
+                    scheduler.verified(current.index)
+                    scheduler.release(id)
+                    claim = null
+                    progressEvents.trySend(Unit)
+                  }
+                }
+                is PeerMessage.Request -> if (uploadSlot && state.interested &&
+                  scheduler.isVerified(message.index)) {
+                  val lease = budget.reserve(store.pieceSize(message.index))
+                  if (lease != null) {
+                    try {
+                      val bytes = storage { store.read(message.index) }
+                      if (!sha1Digest(bytes).contentEquals(store.metadata.pieceHashes.copyOfRange(
+                          message.index * 20, message.index * 20 + 20))) {
+                        throw TorrentStorageException(
+                          IOException("Verified torrent output changed")
+                        )
+                      }
+                      uploadPayload(message.length)
+                      wire.send(PeerMessage.Piece(message.index, message.begin,
+                        bytes.copyOfRange(message.begin, message.begin + message.length)))
+                    } finally {
+                      lease.close()
+                    }
+                  } else {
+                    wire.send(PeerMessage.Control(PeerMessage.Signal.CHOKE))
+                    uploadSlots.release()
+                    uploadSlot = false
+                  }
+                }
+                else -> Unit
+              }
+            }
+            scheduler.snapshot(version)?.let { (nextVersion, pieces) ->
+              version = nextVersion
+              for (index in pieces.indices) {
+                if (pieces[index] && !advertised[index]) {
+                  wire.send(PeerMessage.Have(index))
+                  advertised[index] = true
+                }
+              }
+            }
+            val current = claim
+            if (current != null && scheduler.isVerified(current.index)) {
+              for (request in state.requests) {
+                state.cancel(request)
+                wire.send(PeerMessage.Cancel(request.index, request.begin, request.length))
+              }
+              scheduler.release(id)
+              claim = null
+            }
+            if (state.requests.isNotEmpty() && lastBlock.elapsedNow().inWholeSeconds >= 20) {
+              error("Peer block deadline exceeded")
+            }
+            if (!state.choking && claim == null) {
+              claim = scheduler.claim(id)
+              claim?.let {
+                received = BooleanArray((it.bytes.size + PeerWire.BLOCK_SIZE - 1) /
+                  PeerWire.BLOCK_SIZE)
+                requested = BooleanArray(received.size)
+                receivedBytes = 0
+                lastBlock = TimeSource.Monotonic.markNow()
+              }
+            }
+            claim?.let { assigned ->
+              if (!state.choking) {
+                for (block in requested.indices) {
+                  if (state.requests.size >= 16) break
+                  if (requested[block]) continue
+                  val begin = block * PeerWire.BLOCK_SIZE
+                  val request = PeerMessage.Request(assigned.index, begin,
+                    minOf(PeerWire.BLOCK_SIZE, assigned.bytes.size - begin))
+                  state.requested(request)
+                  wire.send(request)
+                  requested[block] = true
+                  lastWrite = TimeSource.Monotonic.markNow()
+                }
+              }
+            }
+            if (lastWrite.elapsedNow().inWholeSeconds >= 30) {
+              wire.send(PeerMessage.KeepAlive)
+              lastWrite = TimeSource.Monotonic.markNow()
+            }
+          }
+        } finally {
+          withContext(NonCancellable) {
+            reader.cancelAndJoin()
+            runCatching {
+              withTimeoutOrNull(200) {
+                for (request in state.requests) {
+                  wire.send(PeerMessage.Cancel(request.index, request.begin, request.length))
+                }
+              }
+            }
+            messages.cancel()
+          }
+        }
+      } finally {
+        if (uploadSlot) uploadSlots.release()
+        connection.close()
+      }
+    }
+}
+
+internal class TorrentStorageException(cause: IOException) :
+  Exception("Torrent storage failed", cause)
+
+private suspend fun <T> storage(block: suspend () -> T): T = try {
+  block()
+} catch (e: IOException) {
+  throw TorrentStorageException(e)
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -40,6 +40,12 @@ internal class TorrentSwarm(
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
   suspend fun run(peers: ReceiveChannel<PeerEndpoint>) = supervisorScope {
     store.initialize()
+    if (store.completed() && uploadPolicy != TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
+      store.finish()
+      onProgress(store.progress().sum())
+      onCompleted()
+      return@supervisorScope
+    }
     val scheduler = TorrentPieceScheduler(BooleanArray(store.pieceCount) { store.needed(it) },
       store.verifiedPieces(), store::pieceSize, budget)
     val largestPiece = (0 until store.pieceCount).filter { store.needed(it) }
@@ -139,8 +145,9 @@ internal class TorrentSwarm(
     supervisorScope {
       val connection = network.connect(endpoint)
       var uploadSlot = false
+      val uploadCache = TorrentUploadCache(store, budget)
       try {
-        val wire = PeerWire(connection, store.metadata, idleTimeoutMs = 60_000)
+        val wire = PeerWire(connection, store.metadata)
         val handshake = wire.handshake(PeerHandshake(store.metadata.infoHash, peerId, false, false))
         require(!handshake.peerId.contentEquals(peerId)) { "Connected to ourselves" }
         val state = PeerProtocolState(store.pieceCount, maxPending = 16)
@@ -182,14 +189,10 @@ internal class TorrentSwarm(
                     scheduler.release(id)
                     claim = null
                   }
-                  if (message.signal == PeerMessage.Signal.INTERESTED && !uploadSlot &&
-                    uploadPolicy != TorrentUploadPolicy.DISABLED && uploadSlots.tryAcquire()) {
-                    uploadSlot = true
-                    wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
-                  }
                   if (message.signal == PeerMessage.Signal.NOT_INTERESTED && uploadSlot) {
                     uploadSlots.release()
                     uploadSlot = false
+                    uploadCache.close()
                     wire.send(PeerMessage.Control(PeerMessage.Signal.CHOKE))
                   }
                 }
@@ -213,22 +216,11 @@ internal class TorrentSwarm(
                 }
                 is PeerMessage.Request -> if (uploadSlot && state.interested &&
                   scheduler.isVerified(message.index)) {
-                  val lease = budget.reserve(store.pieceSize(message.index))
-                  if (lease != null) {
-                    try {
-                      val bytes = storage { store.read(message.index) }
-                      if (!sha1Digest(bytes).contentEquals(store.metadata.pieceHashes.copyOfRange(
-                          message.index * 20, message.index * 20 + 20))) {
-                        throw TorrentStorageException(
-                          IOException("Verified torrent output changed")
-                        )
-                      }
-                      uploadPayload(message.length)
-                      wire.send(PeerMessage.Piece(message.index, message.begin,
-                        bytes.copyOfRange(message.begin, message.begin + message.length)))
-                    } finally {
-                      lease.close()
-                    }
+                  val bytes = storage { uploadCache.read(message.index) }
+                  if (bytes != null) {
+                    uploadPayload(message.length)
+                    wire.send(PeerMessage.Piece(message.index, message.begin,
+                      bytes.copyOfRange(message.begin, message.begin + message.length)))
                   } else {
                     wire.send(PeerMessage.Control(PeerMessage.Signal.CHOKE))
                     uploadSlots.release()
@@ -237,6 +229,12 @@ internal class TorrentSwarm(
                 }
                 else -> Unit
               }
+            }
+            uploadCache.expire()
+            if (state.interested && !uploadSlot && uploadPolicy != TorrentUploadPolicy.DISABLED &&
+              uploadSlots.tryAcquire()) {
+              uploadSlot = true
+              wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
             }
             scheduler.snapshot(version)?.let { (nextVersion, pieces) ->
               version = nextVersion
@@ -303,6 +301,7 @@ internal class TorrentSwarm(
           }
         }
       } finally {
+        uploadCache.close()
         if (uploadSlot) uploadSlots.release()
         connection.close()
       }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentUploadCache.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentUploadCache.kt
@@ -1,0 +1,48 @@
+package com.linroid.ketch.torrent
+
+import okio.IOException
+import kotlin.time.TimeSource
+
+/** One verified upload piece per peer, charged to the engine budget and evicted when idle. */
+internal class TorrentUploadCache(
+  private val store: TorrentPieceStore,
+  private val budget: TorrentBufferBudget,
+) {
+  private var index = -1
+  private var bytes: ByteArray? = null
+  private var lease: TorrentBufferBudget.Lease? = null
+  private var usedAt = TimeSource.Monotonic.markNow()
+
+  suspend fun read(piece: Int): ByteArray? {
+    if (piece != index) {
+      close()
+      val reserved = budget.reserve(store.pieceSize(piece)) ?: return null
+      try {
+        val data = store.read(piece)
+        if (!sha1Digest(data).contentEquals(store.metadata.pieceHashes.copyOfRange(
+            piece * 20, piece * 20 + 20))) {
+          throw IOException("Verified torrent output changed")
+        }
+        bytes = data
+        index = piece
+        lease = reserved
+      } catch (error: Throwable) {
+        reserved.close()
+        throw error
+      }
+    }
+    usedAt = TimeSource.Monotonic.markNow()
+    return bytes
+  }
+
+  fun expire() {
+    if (usedAt.elapsedNow().inWholeSeconds >= 1) close()
+  }
+
+  fun close() {
+    bytes = null
+    index = -1
+    lease?.close()
+    lease = null
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPieceSchedulerTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPieceSchedulerTest.kt
@@ -1,0 +1,49 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TorrentPieceSchedulerTest {
+  @Test
+  fun scheduler_rarestFirst_releasesDisconnectedWorkAndBoundsEndgame() = runTest {
+    val budget = TorrentBufferBudget(12)
+    val scheduler = TorrentPieceScheduler(BooleanArray(3) { true }, BooleanArray(3), { 4 }, budget)
+    scheduler.availability(1, booleanArrayOf(true, true, true))
+    scheduler.availability(2, booleanArrayOf(false, true, true))
+    assertEquals(0, scheduler.claim(1)?.index)
+    assertEquals(1, scheduler.claim(2)?.index)
+    scheduler.remove(1)
+    assertEquals(4, budget.allocated)
+    scheduler.availability(3, booleanArrayOf(true, true, true))
+    assertEquals(0, scheduler.claim(3)?.index)
+    scheduler.verified(0)
+    scheduler.release(3)
+    assertEquals(2, scheduler.claim(3)?.index)
+    scheduler.availability(4, booleanArrayOf(false, true, false))
+    assertEquals(1, scheduler.claim(4)?.index)
+    scheduler.availability(5, booleanArrayOf(false, true, false))
+    assertNull(scheduler.claim(5))
+    scheduler.verified(1)
+    assertTrue(scheduler.isVerified(1))
+    for (peer in 2..5) scheduler.remove(peer)
+    assertEquals(0, budget.allocated)
+  }
+
+  @Test
+  fun budget_reservationCannotExceedCapacityAndCloseIsIdempotent() {
+    val budget = TorrentBufferBudget(16)
+    val first = assertNotNull(budget.reserve(12))
+    assertNull(budget.reserve(5))
+    val second = assertNotNull(budget.reserve(4))
+    assertEquals(16, budget.allocated)
+    first.close()
+    first.close()
+    assertEquals(4, budget.allocated)
+    second.close()
+    assertEquals(0, budget.allocated)
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmRecoveryTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmRecoveryTest.kt
@@ -1,0 +1,96 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class TorrentSwarmRecoveryTest {
+  @Test
+  fun corruptPeer_isDroppedAndPieceReassigned() = runTest { recover(corrupt = true) }
+
+  @Test
+  fun disconnectedPeer_isReassignedWithoutLeakingBuffers() = runTest { recover(corrupt = false) }
+
+  @Test
+  fun endgame_fasterDuplicateCancelsSlowOutstandingRequest() = runTest {
+    recover(corrupt = false, endgame = true)
+  }
+
+  private suspend fun recover(corrupt: Boolean, endgame: Boolean = false) = withContext(Dispatchers.Default) {
+    withTimeout(15_000) {
+      coroutineScope {
+        val payload = byteArrayOf(1, 2, 3, 4)
+        val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+          "name" to "data", "length" to 4L, "piece length" to 4L,
+          "pieces" to sha1Digest(payload)
+        ))))
+        val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+          "ketch-recover-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+        val store = TorrentPieceStore(metadata, root / "data", emptySet(), "test")
+        val network = createTorrentNetwork()
+        val peers = Channel<PeerEndpoint>(2)
+        val badAttempted = CompletableDeferred<Unit>()
+        val canceled = CompletableDeferred<Unit>()
+        val budget = TorrentBufferBudget(2 * 1024 * 1024)
+        val servers = (0..1).map { number ->
+          val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+          peers.send(listener.local)
+          launch {
+            val connection = listener.accept()
+            try {
+              val wire = PeerWire(connection, metadata)
+              wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+              if (number == 1) badAttempted.await()
+              wire.send(PeerMessage.Bitfield(byteArrayOf(128.toByte())))
+              wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+              while (true) {
+                val message = wire.read()
+                if (message is PeerMessage.Request) {
+                  if (number == 0) {
+                    if (corrupt) wire.send(PeerMessage.Piece(0, 0, byteArrayOf(4, 3, 2, 1)))
+                    badAttempted.complete(Unit)
+                    if (endgame) {
+                      while (true) {
+                        val next = wire.read()
+                        if (next is PeerMessage.Cancel) {
+                          assertEquals(PeerMessage.Cancel(0, 0, 4), next)
+                          canceled.complete(Unit)
+                          break
+                        }
+                      }
+                    }
+                  } else wire.send(PeerMessage.Piece(0, 0, payload))
+                  break
+                }
+              }
+            } finally {
+              connection.close()
+              listener.close()
+            }
+          }
+        }
+        peers.close()
+        try {
+          TorrentSwarm(store, network, budget).run(peers)
+          assertContentEquals(payload, torrentFileSystem.read(root / "data") { readByteArray() })
+          assertEquals(0, budget.allocated)
+          if (endgame) canceled.await()
+        } finally {
+          servers.forEach { it.cancelAndJoin() }
+          network.close()
+          torrentFileSystem.deleteRecursively(root, mustExist = false)
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmReviewTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmReviewTest.kt
@@ -1,0 +1,105 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TorrentSwarmReviewTest {
+  private fun metadata(bytes: ByteArray) = TorrentMetadata.fromBencode(Bencode.encode(
+    mapOf("info" to mapOf("name" to "file", "length" to bytes.size.toLong(),
+      "piece length" to 1L, "pieces" to if (bytes.isEmpty()) ByteArray(0) else sha1Digest(bytes)))
+  ))
+
+  @Test
+  fun emptyAndVerifiedStoresCompleteWithMinimumBuffer() = runTest {
+    for (bytes in listOf(ByteArray(0), byteArrayOf(1))) {
+      val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+        "ketch-complete-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+      val network = createTorrentNetwork()
+      try {
+        val store = TorrentPieceStore(metadata(bytes), root / "file", emptySet(), "test")
+        store.initialize()
+        if (bytes.isNotEmpty()) store.commit(0, bytes)
+        val peers = Channel<PeerEndpoint>().also { it.close() }
+        var completed = 0
+        TorrentSwarm(store, network, TorrentBufferBudget(16384),
+          onCompleted = { completed++ }).run(peers)
+        assertEquals(1, completed)
+        assertTrue(store.completed())
+      } finally {
+        network.close()
+        torrentFileSystem.deleteRecursively(root, mustExist = false)
+      }
+    }
+  }
+
+  @Test
+  fun waitingInterestedPeerGetsReleasedSlotWithoutAnotherInterestedMessage() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(15_000) {
+        coroutineScope {
+          val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+            "ketch-slots-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+          val metadata = metadata(byteArrayOf(1))
+          val store = TorrentPieceStore(metadata, root / "file", emptySet(), "test")
+          store.initialize()
+          store.commit(0, byteArrayOf(1))
+          val network = createTorrentNetwork()
+          val listeners = List(5) { network.listen(PeerEndpoint("127.0.0.1", 0)) }
+          val unchoked = Channel<Int>(5)
+          val release = List(5) { CompletableDeferred<Unit>() }
+          val servers = listeners.mapIndexed { index, listener ->
+            launch {
+              val connection = listener.accept()
+              try {
+                val wire = PeerWire(connection, metadata)
+                wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+                wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
+                while (wire.read() != PeerMessage.Control(PeerMessage.Signal.UNCHOKE)) { }
+                unchoked.send(index)
+                release[index].await()
+                wire.send(PeerMessage.Control(PeerMessage.Signal.NOT_INTERESTED))
+                awaitCancellation()
+              } finally {
+                connection.close()
+              }
+            }
+          }
+          val peers = Channel<PeerEndpoint>(5)
+          listeners.forEach { peers.trySend(it.local) }
+          peers.close()
+          val budget = TorrentBufferBudget(2 * 1024 * 1024)
+          val swarm = async {
+            TorrentSwarm(store, network, budget,
+              uploadPolicy = TorrentUploadPolicy.SEED_AFTER_COMPLETION).run(peers)
+          }
+          try {
+            val first = List(4) { unchoked.receive() }
+            assertTrue(unchoked.tryReceive().isFailure)
+            release[first.first()].complete(Unit)
+            val fifth = withTimeout(3_000) { unchoked.receive() }
+            assertTrue(fifth !in first)
+          } finally {
+            swarm.cancelAndJoin()
+            servers.forEach { it.cancelAndJoin() }
+            network.close()
+            torrentFileSystem.deleteRecursively(root, mustExist = false)
+          }
+          assertEquals(0, budget.allocated)
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmTest.kt
@@ -1,0 +1,90 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TorrentSwarmTest {
+  @Test
+  fun complementaryPeers_withOutOfOrderBlocks_completeAndReleaseMemory() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(15_000) {
+        coroutineScope {
+          val payload = ByteArray(131_073) { (it * 17 + 9).toByte() }
+          val hashes = payload.asList().chunked(65_536).fold(ByteArray(0)) { result, chunk ->
+            result + sha1Digest(chunk.toByteArray())
+          }
+          val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+            "name" to "data", "length" to payload.size.toLong(), "piece length" to 65_536L,
+            "pieces" to hashes
+          ))))
+          val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+            "ketch-swarm-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+          val store = TorrentPieceStore(metadata, root / "data", emptySet(), "swarm")
+          val network = createTorrentNetwork()
+          val budget = TorrentBufferBudget(2 * 1024 * 1024)
+          val peers = Channel<PeerEndpoint>(2)
+          val servers = (0..1).map { number ->
+            val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+            peers.send(listener.local)
+            launch {
+              val connection = listener.accept()
+              try {
+                val wire = PeerWire(connection, metadata)
+                wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+                val available = BooleanArray(3) { it % 2 == number }
+                wire.send(PeerMessage.Bitfield(pieceBitfield(available)))
+                wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+                val requests = mutableListOf<PeerMessage.Request>()
+                while (true) {
+                  val message = wire.read()
+                  if (message is PeerMessage.Request) {
+                    assertTrue(available[message.index])
+                    requests += message
+                    val count = if (message.index == 2) 1 else 4
+                    if (requests.size == count) {
+                      for (request in requests.reversed()) {
+                        val begin = request.index * 65_536 + request.begin
+                        wire.send(PeerMessage.Piece(request.index, request.begin,
+                          payload.copyOfRange(begin, begin + request.length)))
+                      }
+                      requests.clear()
+                    }
+                  }
+                }
+              } catch (_: okio.IOException) {
+                // The completed downloader closes the connections.
+              } catch (e: CancellationException) {
+                throw e
+              } finally {
+                connection.close()
+              }
+            }
+          }
+          peers.close()
+          try {
+            TorrentSwarm(store, network, budget).run(peers)
+            assertTrue(store.completed())
+            assertContentEquals(payload, torrentFileSystem.read(root / "data") { readByteArray() })
+            assertEquals(0, budget.allocated)
+          } finally {
+            servers.forEach { it.cancelAndJoin() }
+            network.close()
+            torrentFileSystem.deleteRecursively(root, mustExist = false)
+          }
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentUploadCacheTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentUploadCacheTest.kt
@@ -1,0 +1,51 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import okio.FileHandle
+import okio.FileSystem
+import okio.ForwardingFileSystem
+import okio.Path
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class TorrentUploadCacheTest {
+  @Test
+  fun blockBurstReadsOnePieceAndReleasesItsReservation() = runTest {
+    val bytes = ByteArray(32768) { it.toByte() }
+    val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+      "name" to "file", "length" to bytes.size.toLong(),
+      "piece length" to bytes.size.toLong(), "pieces" to sha1Digest(bytes)
+    ))))
+    var reads = 0
+    val fs = object : ForwardingFileSystem(torrentFileSystem) {
+      override fun openReadOnly(file: Path): FileHandle {
+        reads++
+        return super.openReadOnly(file)
+      }
+    }
+    val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+      "ketch-upload-cache-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+    val budget = TorrentBufferBudget(bytes.size)
+    val store = TorrentPieceStore(metadata, root / "file", emptySet(), "test", fs)
+    val cache = TorrentUploadCache(store, budget)
+    try {
+      store.initialize()
+      store.commit(0, bytes)
+      val before = reads
+      for (begin in listOf(0, 16384)) {
+        val piece = assertNotNull(cache.read(0))
+        assertContentEquals(bytes.copyOfRange(begin, begin + 16384),
+          piece.copyOfRange(begin, begin + 16384))
+      }
+      assertEquals(1, reads - before)
+      assertEquals(bytes.size, budget.allocated)
+      cache.close()
+      assertEquals(0, budget.allocated)
+    } finally {
+      cache.close()
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentUploadTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentUploadTest.kt
@@ -1,0 +1,119 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class TorrentUploadTest {
+  @Test
+  fun disabled_neverUnchokesOrServesRequests() = runTest { transfer(TorrentUploadPolicy.DISABLED) }
+
+  @Test
+  fun whileDownloading_servesVerifiedBytesThroughUploadLimiter() = runTest {
+    transfer(TorrentUploadPolicy.WHILE_DOWNLOADING)
+  }
+
+  @Test
+  fun seedAfterCompletion_keepsSessionUntilCanceledAndReleasesResources() = runTest {
+    transfer(TorrentUploadPolicy.SEED_AFTER_COMPLETION)
+  }
+
+  private suspend fun transfer(policy: TorrentUploadPolicy) = withContext(Dispatchers.Default) {
+    withTimeout(15_000) {
+      coroutineScope {
+        val first = byteArrayOf(1, 2, 3, 4)
+        val second = byteArrayOf(5, 6, 7)
+        val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+          "name" to "data", "length" to 7L, "piece length" to 4L,
+          "pieces" to (sha1Digest(first) + sha1Digest(second))
+        ))))
+        val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+          "ketch-upload-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+        val store = TorrentPieceStore(metadata, root / "data", emptySet(), "test")
+        store.initialize()
+        store.commit(0, first)
+        val network = createTorrentNetwork()
+        val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+        val budget = TorrentBufferBudget(1024 * 1024)
+        val completed = CompletableDeferred<Unit>()
+        var uploaded = 0
+        val server = launch {
+          val connection = listener.accept()
+          try {
+            val wire = PeerWire(connection, metadata)
+            wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+            wire.send(PeerMessage.Bitfield(pieceBitfield(booleanArrayOf(false, true))))
+            wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+            wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
+            if (policy == TorrentUploadPolicy.DISABLED) wire.send(PeerMessage.Request(0, 0, 4))
+            var downloadRequest = false
+            var servedUpload = false
+            var delivered = false
+            while (true) {
+              when (val message = wire.read()) {
+                is PeerMessage.Control -> if (message.signal == PeerMessage.Signal.UNCHOKE) {
+                  assertFalse(policy == TorrentUploadPolicy.DISABLED)
+                  wire.send(PeerMessage.Request(0, 0, 4))
+                }
+                is PeerMessage.Request -> {
+                  assertEquals(PeerMessage.Request(1, 0, 3), message)
+                  downloadRequest = true
+                }
+                is PeerMessage.Piece -> {
+                  assertContentEquals(first, message.bytes)
+                  assertEquals(4, uploaded)
+                  servedUpload = true
+                }
+                else -> Unit
+              }
+              if (!delivered && downloadRequest &&
+                (servedUpload || policy == TorrentUploadPolicy.DISABLED)) {
+                wire.send(PeerMessage.Piece(1, 0, second))
+                delivered = true
+              }
+            }
+          } catch (_: okio.IOException) {
+            // Download completion/cancellation closes the connection.
+          } finally {
+            connection.close()
+          }
+        }
+        val peers = Channel<PeerEndpoint>(1)
+        peers.send(listener.local)
+        peers.close()
+        val download = async {
+          TorrentSwarm(store, network, budget, uploadPolicy = policy,
+            uploadPayload = { uploaded += it }, onCompleted = { completed.complete(Unit) }).run(peers)
+        }
+        try {
+          completed.await()
+          if (policy == TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
+            assertFalse(download.isCompleted)
+            download.cancelAndJoin()
+          } else download.await()
+          assertEquals(if (policy == TorrentUploadPolicy.DISABLED) 0 else 4, uploaded)
+          assertEquals(0, budget.allocated)
+          assertContentEquals(first + second,
+            torrentFileSystem.read(root / "data") { readByteArray() })
+        } finally {
+          download.cancelAndJoin()
+          server.cancelAndJoin()
+          network.close()
+          torrentFileSystem.deleteRecursively(root, mustExist = false)
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
+++ b/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
@@ -2,6 +2,7 @@ package com.linroid.ketch.torrent
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -55,10 +56,11 @@ class IndependentSeederTest {
           val store = TorrentPieceStore(metadata, output.absolutePath.toPath(), emptySet(), "interop")
           var received = 0L
           val progress = mutableListOf<Long>()
-          TorrentPeerDownloader(store, network, consumePayload = { received += it },
-            onProgress = { progress.add(it) }).download(
-            PeerEndpoint("127.0.0.1", manager.swig().listen_port())
-          )
+          val peers = Channel<PeerEndpoint>(1)
+          peers.send(PeerEndpoint("127.0.0.1", manager.swig().listen_port()))
+          peers.close()
+          TorrentSwarm(store, network, TorrentBufferBudget(4 * 1024 * 1024),
+            downloadPayload = { received += it }, onProgress = { progress.add(it) }).run(peers)
           assertContentEquals(payload, output.readBytes())
           assertEquals(payload.size.toLong(), received)
           assertEquals(payload.size.toLong(), progress.last())


### PR DESCRIPTION
Adds multi-peer transfer scheduling with rarity-based piece choice, 16-block request pipelines, out-of-order assembly, bounded retries, corrupt-peer rejection, and bounded endgame duplication/cancellation. Shared reservations cover piece buffers and peer protocol state; progress callbacks are serialized through the session loop.

Upload policies enforce choking and four upload slots, serve hash-checked verified data through a separate payload limiter, and keep explicitly requested seeding alive after download completion. Disk failures are distinguished from peer failures. Incoming listener routing and public engine integration follow in the integration layer.

Validation: all torrent tests pass on JVM, Android host and iOS simulator. Tests cover complementary peers, out-of-order blocks, corruption/disconnection recovery, endgame cancel messages, buffer release, disabled uploads, verified limited uploads, and seeding cancellation. JVM transfers also pass against the independent libtorrent seeder using the new swarm path.

Layer 8 of the approved stack, based on #154.
