### PR TITLE
feat(torrent): verified magnet metadata exchange and shared cache

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -12,8 +12,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 05 Verified storage | https://github.com/linroid/Ketch/pull/152 | Draft; local JVM/Android/iOS gates passed |
 | 06 First verified transfer | https://github.com/linroid/Ketch/pull/153 | JVM independent libtorrent seeder passed; JVM/Android/iOS loopback transfer and corruption gates passed |
 | 07 Tracker discovery | https://github.com/linroid/Ketch/pull/154 | Local HTTP parsing, IPv4/IPv6 UDP, tier and lifecycle validation |
-| 08 Swarm and upload | Pending PR | Rarity/pipelines, complementary peers, recovery, upload policies and seeding lifecycle on JVM/Android/iOS |
-| 09–14 | Pending | Not implemented yet |
+| 08 Swarm and upload | https://github.com/linroid/Ketch/pull/155 | Rarity/pipelines, complementary peers, recovery, upload policies and seeding lifecycle on JVM/Android/iOS |
+| 09 Magnet metadata | Pending PR | Independent seeder metadata-to-payload transfer; common negotiation, hash/size/private validation and shared cache tests |
+| 10–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerExtensions.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerExtensions.kt
@@ -1,0 +1,50 @@
+package com.linroid.ketch.torrent
+
+/** BEP 10 IDs belong to the receiving peer. Repeated handshakes update the existing mapping. */
+internal class PeerExtensions {
+  private val ids = mutableMapOf<String, Int>()
+  var metadataSize: Int? = null
+    private set
+
+  fun id(name: String): Int = ids[name] ?: 0
+
+  fun receive(bytes: ByteArray, maxMetadataBytes: Int) {
+    val root = Bencode.parse(bytes, PeerWire.MAX_FRAME_SIZE)
+    require(root.dictionary != null)
+    root["m"]?.let { mapping ->
+      val entries = requireNotNull(mapping.dictionary)
+      require(entries.size <= 64)
+      val updated = ids.toMutableMap()
+      for ((name, value) in entries) {
+        require(name.size <= 64)
+        val id = requireNotNull(value.integer)
+        require(id in 0..255)
+        updated[name.utf8()] = id.toInt()
+      }
+      require(updated.size <= 64)
+      val active = updated.values.filter { it != 0 }
+      require(active.distinct().size == active.size) { "Duplicate peer extension IDs" }
+      ids.clear()
+      ids.putAll(updated)
+    }
+    root["metadata_size"]?.let { size ->
+      val value = requireNotNull(size.integer)
+      require(value in 1..maxMetadataBytes.toLong()) { "Peer metadata exceeds limit" }
+      require(metadataSize == null || metadataSize == value.toInt()) { "Metadata size changed" }
+      metadataSize = value.toInt()
+    }
+  }
+
+  companion object {
+    const val METADATA = 1
+    const val PEX = 2
+
+    fun handshake(metadata: TorrentMetadata? = null, pex: Boolean = false): PeerMessage.Extended {
+      val mapping = mutableMapOf("ut_metadata" to METADATA.toLong())
+      if (pex) mapping["ut_pex"] = PEX.toLong()
+      val values = mutableMapOf<String, Any>("m" to mapping, "reqq" to 16L)
+      if (metadata != null) values["metadata_size"] = metadata.infoBytes.size.toLong()
+      return PeerMessage.Extended(0, Bencode.encode(values))
+    }
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadataCache.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadataCache.kt
@@ -1,0 +1,65 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.async
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/** Runtime-owned shared fetches; cancellation of one caller does not cancel other waiters. */
+internal class TorrentMetadataCache(
+  private val scope: CoroutineScope,
+  private val capacityBytes: Int = 32 * 1024 * 1024,
+) {
+  init { require(capacityBytes > 0) }
+
+  private val mutex = Mutex()
+  private val entries = linkedMapOf<InfoHash, TorrentMetadata>()
+  private val pending = mutableMapOf<InfoHash, Deferred<TorrentMetadata>>()
+  private var bytes = 0L
+
+  suspend fun get(hash: InfoHash): TorrentMetadata? = mutex.withLock {
+    scope.coroutineContext.ensureActive()
+    entries.remove(hash)?.also { entries[hash] = it }
+  }
+
+  suspend fun resolve(hash: InfoHash, fetch: suspend () -> TorrentMetadata): TorrentMetadata {
+    get(hash)?.let { return it }
+    val operation = mutex.withLock {
+      scope.coroutineContext.ensureActive()
+      pending.getOrPut(hash) {
+        check(pending.size < 16) { "Too many pending metadata requests" }
+        scope.async {
+          try {
+            val metadata = get(hash) ?: fetch()
+            require(metadata.infoHash == hash)
+            put(metadata)
+            metadata
+          } finally {
+            withContext(NonCancellable) { mutex.withLock { pending.remove(hash) } }
+          }
+        }
+      }
+    }
+    return operation.await()
+  }
+
+  suspend fun put(metadata: TorrentMetadata) = mutex.withLock {
+    scope.coroutineContext.ensureActive()
+    val size = weight(metadata)
+    entries.remove(metadata.infoHash)?.let { bytes -= weight(it) }
+    if (size > capacityBytes) return@withLock
+    while (entries.isNotEmpty() && (bytes + size > capacityBytes || entries.size >= 8)) {
+      val key = entries.keys.first()
+      bytes -= weight(checkNotNull(entries.remove(key)))
+    }
+    entries[metadata.infoHash] = metadata
+    bytes += size
+  }
+
+  private fun weight(metadata: TorrentMetadata): Long = metadata.metainfoBytes.size.toLong() +
+    metadata.infoBytes.size + metadata.pieceHashes.size + metadata.files.sumOf { it.path.length * 2L }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadataCache.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadataCache.kt
@@ -37,7 +37,6 @@ internal class TorrentMetadataCache(
             val metadata = get(hash) ?: fetch()
             require(metadata.infoHash == hash)
             put(metadata)
-            metadata
           } finally {
             withContext(NonCancellable) { mutex.withLock { pending.remove(hash) } }
           }
@@ -47,17 +46,26 @@ internal class TorrentMetadataCache(
     return operation.await()
   }
 
-  suspend fun put(metadata: TorrentMetadata) = mutex.withLock {
+  suspend fun put(value: TorrentMetadata): TorrentMetadata = mutex.withLock {
+    // The info hash authenticates only the info dictionary, never caller tracker credentials.
+    val metadata = value.copy(
+      trackers = emptyList(),
+      trackerTiers = emptyList(),
+      comment = null,
+      createdBy = null,
+      metainfoBytes = metainfoFromInfo(value.infoBytes, emptyList()),
+    )
     scope.coroutineContext.ensureActive()
     val size = weight(metadata)
     entries.remove(metadata.infoHash)?.let { bytes -= weight(it) }
-    if (size > capacityBytes) return@withLock
+    if (size > capacityBytes) return@withLock metadata
     while (entries.isNotEmpty() && (bytes + size > capacityBytes || entries.size >= 8)) {
       val key = entries.keys.first()
       bytes -= weight(checkNotNull(entries.remove(key)))
     }
     entries[metadata.infoHash] = metadata
     bytes += size
+    metadata
   }
 
   private fun weight(metadata: TorrentMetadata): Long = metadata.metainfoBytes.size.toLong() +

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadataExchange.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentMetadataExchange.kt
@@ -1,0 +1,130 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.delay
+import okio.Buffer
+
+/** BEP 9 bounded metadata exchange, with four outstanding blocks and full hash verification. */
+internal class TorrentMetadataExchange(
+  private val network: TorrentNetwork,
+  private val maxBytes: Int = 4 * 1024 * 1024,
+  private val timeoutMs: Long = 30_000,
+  private val budget: TorrentBufferBudget = TorrentBufferBudget(32 * 1024 * 1024),
+) {
+  init {
+    require(maxBytes in 1..4 * 1024 * 1024 && timeoutMs > 0)
+    require(budget.capacity >= maxBytes * 4 + 256 * 1024)
+  }
+
+  suspend fun fetch(
+    hash: InfoHash,
+    endpoint: PeerEndpoint,
+    trackerTiers: List<List<String>> = emptyList(),
+  ): TorrentMetadata = withTimeout(timeoutMs) {
+    var lease: TorrentBufferBudget.Lease? = null
+    while (lease == null) {
+      lease = budget.reserve(maxBytes * 4 + 256 * 1024)
+      if (lease == null) delay(10)
+    }
+    var connection: TorrentConnection? = null
+    try {
+      connection = network.connect(endpoint)
+      val wire = PeerWire(connection)
+      val peerId = torrentRandomBytes(20)
+      val handshake = wire.handshake(PeerHandshake(hash, peerId, true, false))
+      require(handshake.extensions && !handshake.peerId.contentEquals(peerId)) {
+        "Peer does not support metadata exchange"
+      }
+      wire.send(PeerExtensions.handshake())
+      val extensions = PeerExtensions()
+      var data: ByteArray? = null
+      var received = BooleanArray(0)
+      val pending = mutableSetOf<Int>()
+      var next = 0
+      var receivedCount = 0
+      while (true) {
+        val message = wire.read()
+        require(message !is PeerMessage.Piece) { "Unsolicited data during metadata exchange" }
+        if (message !is PeerMessage.Extended) continue
+        if (message.id == 0) {
+          extensions.receive(message.payload, maxBytes)
+          val size = extensions.metadataSize
+          if (data == null && size != null && extensions.id("ut_metadata") != 0) {
+            data = ByteArray(size)
+            received = BooleanArray((size + BLOCK_SIZE - 1) / BLOCK_SIZE)
+          }
+        } else if (message.id == PeerExtensions.METADATA) {
+          val header = Bencode.parsePrefix(message.payload, PeerWire.MAX_FRAME_SIZE)
+          val type = requireNotNull(header["msg_type"]?.integer)
+          if (type !in 0..2) continue
+          val piece = requireNotNull(header["piece"]?.integer)
+          require(piece in 0..Int.MAX_VALUE.toLong())
+          if (type == 0L) {
+            val remoteId = extensions.id("ut_metadata")
+            if (remoteId != 0) wire.send(metadataMessage(remoteId, 2, piece.toInt()))
+            continue
+          }
+          val output = requireNotNull(data) { "Metadata arrived before negotiation" }
+          require(piece.toInt() in pending) { "Unrequested metadata block" }
+          require(type != 2L) { "Peer rejected metadata request" }
+          require(header["total_size"]?.integer == output.size.toLong()) {
+            "Metadata size changed"
+          }
+          val offset = piece.toInt() * BLOCK_SIZE
+          val count = minOf(BLOCK_SIZE, output.size - offset)
+          require(message.payload.size - header.end == count) { "Invalid metadata block length" }
+          message.payload.copyInto(output, offset, header.end)
+          pending.remove(piece.toInt())
+          received[piece.toInt()] = true
+          receivedCount++
+          if (receivedCount == received.size) {
+            require(InfoHash.fromBytes(sha1Digest(output)) == hash) { "Metadata hash mismatch" }
+            val metainfo = metainfoFromInfo(output, trackerTiers)
+            val metadata = TorrentMetadata.fromBencode(metainfo)
+            if (metadata.isPrivate) throw PrivateTorrentMagnetException()
+            return@withTimeout metadata
+          }
+        }
+        val id = extensions.id("ut_metadata")
+        if (id != 0 && data != null) {
+          while (pending.size < 4 && next < received.size) {
+            pending += next
+            wire.send(metadataMessage(id, 0, next++))
+          }
+        }
+      }
+      @Suppress("UNREACHABLE_CODE")
+      error("Metadata exchange ended")
+    } finally {
+      connection?.close()
+      lease.close()
+    }
+  }
+
+  companion object {
+    const val BLOCK_SIZE = 16_384
+
+    fun metadataMessage(id: Int, type: Int, piece: Int): PeerMessage.Extended =
+      PeerMessage.Extended(id, Bencode.encode(mapOf("msg_type" to type.toLong(),
+        "piece" to piece.toLong())))
+
+    fun response(id: Int, piece: Int, metadata: TorrentMetadata): PeerMessage.Extended {
+      val offset = piece.toLong() * BLOCK_SIZE
+      if (piece < 0 || offset >= metadata.infoBytes.size) return metadataMessage(id, 2, piece)
+      val header = Bencode.encode(mapOf("msg_type" to 1L, "piece" to piece.toLong(),
+        "total_size" to metadata.infoBytes.size.toLong()))
+      return PeerMessage.Extended(id, header + metadata.infoBytes.copyOfRange(offset.toInt(),
+        minOf(offset + BLOCK_SIZE, metadata.infoBytes.size.toLong()).toInt()))
+    }
+  }
+}
+
+/** Wraps the original info bytes without re-encoding their identity-bearing dictionary. */
+internal fun metainfoFromInfo(info: ByteArray, trackerTiers: List<List<String>>): ByteArray {
+  val prefix = Bencode.encode(mapOf("announce-list" to trackerTiers))
+  return Buffer().write(prefix, 0, prefix.size - 1).writeUtf8("4:info").write(info)
+    .writeByte('e'.code).readByteArray()
+}
+
+internal class PrivateTorrentMagnetException :
+  IllegalArgumentException("Private torrents require a metainfo input")

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -148,8 +148,12 @@ internal class TorrentSwarm(
       val uploadCache = TorrentUploadCache(store, budget)
       try {
         val wire = PeerWire(connection, store.metadata)
-        val handshake = wire.handshake(PeerHandshake(store.metadata.infoHash, peerId, false, false))
+        val handshake = wire.handshake(PeerHandshake(store.metadata.infoHash, peerId, true, false))
         require(!handshake.peerId.contentEquals(peerId)) { "Connected to ourselves" }
+        val extensions = PeerExtensions()
+        var metadataServed = 0
+        var metadataWindow = TimeSource.Monotonic.markNow()
+        if (handshake.extensions) wire.send(PeerExtensions.handshake(store.metadata))
         val state = PeerProtocolState(store.pieceCount, maxPending = 16)
         val advertised = store.verifiedPieces()
         var version = -1L
@@ -225,6 +229,30 @@ internal class TorrentSwarm(
                     wire.send(PeerMessage.Control(PeerMessage.Signal.CHOKE))
                     uploadSlots.release()
                     uploadSlot = false
+                  }
+                }
+                is PeerMessage.Extended -> {
+                  require(handshake.extensions) { "Unnegotiated peer extension" }
+                  if (message.id == 0) extensions.receive(message.payload, 4 * 1024 * 1024)
+                  else if (message.id == PeerExtensions.METADATA) {
+                    val header = Bencode.parse(message.payload, PeerWire.MAX_FRAME_SIZE)
+                    if (header["msg_type"]?.integer == 0L) {
+                      val index = requireNotNull(header["piece"]?.integer)
+                      require(index in 0..Int.MAX_VALUE.toLong())
+                      val remoteId = extensions.id("ut_metadata")
+                      if (remoteId != 0) {
+                        if (metadataWindow.elapsedNow().inWholeSeconds >= 60) {
+                          metadataServed = 0
+                          metadataWindow = TimeSource.Monotonic.markNow()
+                        }
+                        val limit = (store.metadata.infoBytes.size / 16_384 + 1) * 3
+                        val response = if (metadataServed < limit) {
+                          metadataServed++
+                          TorrentMetadataExchange.response(remoteId, index.toInt(), store.metadata)
+                        } else TorrentMetadataExchange.metadataMessage(remoteId, 2, index.toInt())
+                        wire.send(response)
+                      }
+                    }
                   }
                 }
                 else -> Unit

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentMetadataCacheTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentMetadataCacheTest.kt
@@ -1,0 +1,35 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TorrentMetadataCacheTest {
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  @Test
+  fun sharedFetch_survivesOneWaiterCancelAndAvoidsHandoffRefetch() = runTest {
+    val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+      "name" to "empty", "length" to 0L, "piece length" to 16_384L, "pieces" to ByteArray(0)
+    ))))
+    val cache = TorrentMetadataCache(backgroundScope)
+    val ready = CompletableDeferred<Unit>()
+    var fetches = 0
+    val fetch: suspend () -> TorrentMetadata = {
+      fetches++
+      ready.await()
+      metadata
+    }
+    val first = async { cache.resolve(metadata.infoHash, fetch) }
+    val second = async { cache.resolve(metadata.infoHash, fetch) }
+    runCurrent()
+    first.cancelAndJoin()
+    ready.complete(Unit)
+    assertEquals(metadata.infoHash, second.await().infoHash)
+    assertEquals(metadata.infoHash, cache.resolve(metadata.infoHash, fetch).infoHash)
+    assertEquals(1, fetches)
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentMetadataCacheTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentMetadataCacheTest.kt
@@ -9,6 +9,28 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class TorrentMetadataCacheTest {
+  @Test
+  fun sharedAndCachedResultsExcludeCallerTrackerCredentials() = runTest {
+    val info = Bencode.encode(mapOf("name" to "empty", "length" to 0L,
+      "piece length" to 1L, "pieces" to ByteArray(0)))
+    val first = TorrentMetadata.fromBencode(metainfoFromInfo(info,
+      listOf(listOf("https://tracker.example/first-passkey"))))
+    val second = TorrentMetadata.fromBencode(metainfoFromInfo(info,
+      listOf(listOf("https://tracker.example/second-passkey"))))
+    val cache = TorrentMetadataCache(backgroundScope)
+    val gate = CompletableDeferred<Unit>()
+    var fetches = 0
+    val one = async { cache.resolve(first.infoHash) { fetches++; gate.await(); first } }
+    val two = async { cache.resolve(second.infoHash) { fetches++; gate.await(); second } }
+    gate.complete(Unit)
+    for (result in listOf(one.await(), two.await(), cache.get(first.infoHash)!!)) {
+      assertEquals(emptyList(), result.trackers)
+      assertEquals(emptyList(), result.trackerTiers)
+      assertEquals(emptyList(), TorrentMetadata.fromBencode(result.metainfoBytes).trackers)
+    }
+    assertEquals(1, fetches)
+  }
+
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
   @Test
   fun sharedFetch_survivesOneWaiterCancelAndAvoidsHandoffRefetch() = runTest {

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentMetadataExchangeTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentMetadataExchangeTest.kt
@@ -1,0 +1,102 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class TorrentMetadataExchangeTest {
+  @Test
+  fun exchange_usesPerPeerIdAndAssemblesReorderedBlocks() = runTest { exchange("valid") }
+
+  @Test
+  fun exchange_hashMismatchFailsBeforeHandoff() = runTest { exchange("corrupt") }
+
+  @Test
+  fun exchange_oversizedMetadataFailsBeforeAllocation() = runTest { exchange("oversized") }
+
+  @Test
+  fun exchange_privateMetainfoRequiresExplicitInput() = runTest { exchange("private") }
+
+  @Test
+  fun extensions_updatesAreAdditiveAndCanDisableAnId() {
+    val extensions = PeerExtensions()
+    extensions.receive(Bencode.encode(mapOf("m" to mapOf("ut_metadata" to 7L, "ut_pex" to 4L))),
+      1024)
+    extensions.receive(Bencode.encode(mapOf("m" to mapOf("ut_metadata" to 0L))), 1024)
+    assertEquals(0, extensions.id("ut_metadata"))
+    assertEquals(4, extensions.id("ut_pex"))
+    assertFailsWith<IllegalArgumentException> {
+      extensions.receive(Bencode.encode(mapOf("m" to mapOf("ut_metadata" to 4L))), 1024)
+    }
+  }
+
+  private suspend fun exchange(mode: String) = withContext(Dispatchers.Default) {
+    withTimeout(15_000) {
+      coroutineScope {
+        val info = mutableMapOf<String, Any>("name" to "fixture", "length" to 0L,
+          "piece length" to 16_384L, "pieces" to ByteArray(0), "padding" to "x".repeat(40_000))
+        if (mode == "private") info["private"] = 1L
+        val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to info)))
+        val network = createTorrentNetwork()
+        val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+        val budget = TorrentBufferBudget(32 * 1024 * 1024)
+        val server = async {
+          val connection = listener.accept()
+          try {
+            val wire = PeerWire(connection)
+            wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), true, false))
+            val local = wire.read() as PeerMessage.Extended
+            assertEquals(1L, Bencode.parse(local.payload)["m"]?.get("ut_metadata")?.integer)
+            wire.send(PeerMessage.Extended(0, Bencode.encode(mapOf(
+              "m" to mapOf("ut_metadata" to 7L),
+              "metadata_size" to if (mode == "oversized") 5_000_000L
+                else metadata.infoBytes.size.toLong()
+            ))))
+            if (mode != "oversized") {
+              val requests = (0..2).map {
+                val request = wire.read() as PeerMessage.Extended
+                assertEquals(7, request.id)
+                Bencode.parse(request.payload)["piece"]!!.integer!!.toInt()
+              }
+              for (piece in requests.reversed()) {
+                val response = TorrentMetadataExchange.response(1, piece, metadata)
+                if (mode == "corrupt") {
+                  response.payload[response.payload.lastIndex] = '!'.code.toByte()
+                }
+                wire.send(response)
+              }
+            }
+          } finally {
+            connection.close()
+          }
+        }
+        try {
+          val exchange = TorrentMetadataExchange(network, budget = budget)
+          if (mode == "valid") {
+            val result = exchange.fetch(metadata.infoHash, listener.local,
+              listOf(listOf("http://tracker/announce")))
+            assertContentEquals(metadata.infoBytes, result.infoBytes)
+            assertEquals(listOf("http://tracker/announce"), result.trackers)
+          } else {
+            assertFailsWith<IllegalArgumentException> {
+              exchange.fetch(metadata.infoHash, listener.local)
+            }
+          }
+          server.await()
+          assertEquals(0, budget.allocated)
+        } finally {
+          server.cancelAndJoin()
+          network.close()
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentUploadTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentUploadTest.kt
@@ -48,12 +48,14 @@ class TorrentUploadTest {
         val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
         val budget = TorrentBufferBudget(1024 * 1024)
         val completed = CompletableDeferred<Unit>()
+        val metadataServed = CompletableDeferred<Unit>()
         var uploaded = 0
         val server = launch {
           val connection = listener.accept()
           try {
             val wire = PeerWire(connection, metadata)
-            wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+            wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20),
+              policy == TorrentUploadPolicy.SEED_AFTER_COMPLETION, false))
             wire.send(PeerMessage.Bitfield(pieceBitfield(booleanArrayOf(false, true))))
             wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
             wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
@@ -75,6 +77,20 @@ class TorrentUploadTest {
                   assertContentEquals(first, message.bytes)
                   assertEquals(4, uploaded)
                   servedUpload = true
+                }
+                is PeerMessage.Extended -> {
+                  if (message.id == 0) {
+                    wire.send(PeerMessage.Extended(0, Bencode.encode(mapOf(
+                      "m" to mapOf("ut_metadata" to 7L)
+                    ))))
+                    wire.send(TorrentMetadataExchange.metadataMessage(1, 0, 0))
+                  } else {
+                    assertEquals(7, message.id)
+                    val header = Bencode.parsePrefix(message.payload)
+                    assertContentEquals(metadata.infoBytes,
+                      message.payload.copyOfRange(header.end, message.payload.size))
+                    metadataServed.complete(Unit)
+                  }
                 }
                 else -> Unit
               }
@@ -100,6 +116,7 @@ class TorrentUploadTest {
         try {
           completed.await()
           if (policy == TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
+            metadataServed.await()
             assertFalse(download.isCompleted)
             download.cancelAndJoin()
           } else download.await()

--- a/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
+++ b/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
@@ -52,7 +52,10 @@ class IndependentSeederTest {
             delay(20)
           }
           val output = root.resolve("download/fixture.bin")
-          val metadata = TorrentMetadata.fromBencode(data)
+          val expected = TorrentMetadata.fromBencode(data)
+          val metadata = TorrentMetadataExchange(network).fetch(expected.infoHash,
+            PeerEndpoint("127.0.0.1", manager.swig().listen_port()))
+          assertContentEquals(expected.infoBytes, metadata.infoBytes)
           val store = TorrentPieceStore(metadata, output.absolutePath.toPath(), emptySet(), "interop")
           var received = 0L
           val progress = mutableListOf<Long>()


### PR DESCRIPTION
Adds BEP 9/10 metadata negotiation with per-peer extension IDs, bounded four-block pipelines, reordered assembly, exact info-hash verification, private-magnet rejection, and runtime-owned shared metadata caching. One canceled caller cannot cancel another caller's metadata fetch. Swarm peers now serve verified metadata with a bounded request quota.

Validation: all torrent tests pass on JVM, Android host, and iOS simulator. Common fixtures verify differing extension IDs, reordered metadata blocks, oversize/hash/private rejection, metadata serving, and shared-cache cancellation. The JVM independent seeder test now obtains metadata through the Kotlin extension protocol before transferring and verifying the payload. Tracker/DHT orchestration and public magnet inputs are wired at the runtime integration layer.

Layer 9 of the approved stack, based on #155.
