### PR TITLE
feat(torrent): bounded DHT routing, identity, tokens and RPC

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -13,8 +13,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 06 First verified transfer | https://github.com/linroid/Ketch/pull/153 | JVM independent libtorrent seeder passed; JVM/Android/iOS loopback transfer and corruption gates passed |
 | 07 Tracker discovery | https://github.com/linroid/Ketch/pull/154 | Local HTTP parsing, IPv4/IPv6 UDP, tier and lifecycle validation |
 | 08 Swarm and upload | https://github.com/linroid/Ketch/pull/155 | Rarity/pipelines, complementary peers, recovery, upload policies and seeding lifecycle on JVM/Android/iOS |
-| 09 Magnet metadata | Pending PR | Independent seeder metadata-to-payload transfer; common negotiation, hash/size/private validation and shared cache tests |
-| 10–14 | Pending | Not implemented yet |
+| 09 Magnet metadata | https://github.com/linroid/Ketch/pull/156 | Independent seeder metadata-to-payload transfer; common negotiation, hash/size/private validation and shared cache tests |
+| 10 DHT foundations | Pending PR | Published BEP 42/CRC vectors, routing/token expiry, packet quotas and IPv4/IPv6 RPC correlation |
+| 11–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtCodec.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtCodec.kt
@@ -1,0 +1,133 @@
+package com.linroid.ketch.torrent
+
+import okio.Buffer
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+
+internal data class DhtContact(val id: ByteString, val endpoint: PeerEndpoint) {
+  init { require(id.size == 20 && endpoint.port != 0) }
+}
+
+internal data class DhtMessage(
+  val transaction: ByteString,
+  val type: String,
+  val root: Bencode.Node,
+) {
+  val body: Bencode.Node? get() = root[if (type == "q") "a" else "r"]
+  val query: String? get() = root["q"]?.text()
+}
+
+internal object DhtCodec {
+  const val MAX_SEND = 1024
+  const val MAX_RECEIVE = 4096
+
+  fun parse(bytes: ByteArray): DhtMessage {
+    val root = Bencode.parse(bytes, MAX_RECEIVE)
+    require(root.dictionary != null)
+    val transaction = requireNotNull(root["t"]?.bytes).toByteString()
+    require(transaction.size in 1..8)
+    val type = root["y"]?.text()
+    require(type == "q" || type == "r" || type == "e")
+    if (type == "e") {
+      val error = requireNotNull(root["e"]?.list)
+      require(error.size == 2 && error[0].integer != null && error[1].bytes != null)
+    } else {
+      val body = requireNotNull(root[if (type == "q") "a" else "r"])
+      require(body.dictionary != null && body["id"]?.bytes?.size == 20)
+      if (type == "q") require(root["q"]?.bytes?.size in 1..32)
+    }
+    return DhtMessage(transaction, type, root)
+  }
+
+  fun query(transaction: ByteString, name: String, arguments: Map<String, Any>): ByteArray =
+    encode(mapOf("t" to transaction.toByteArray(), "y" to "q", "q" to name, "a" to arguments))
+
+  fun response(
+    transaction: ByteString,
+    values: Map<String, Any>,
+    observed: PeerEndpoint,
+  ): ByteArray = encode(mapOf("t" to transaction.toByteArray(), "y" to "r", "r" to values,
+    "ip" to compactEndpoint(observed)))
+
+  fun error(transaction: ByteString, code: Int): ByteArray = encode(mapOf(
+    "t" to transaction.toByteArray(), "y" to "e", "e" to listOf(code.toLong(), "DHT error")
+  ))
+
+  fun nodes(bytes: ByteArray, ipv6: Boolean): List<DhtContact> {
+    val stride = if (ipv6) 38 else 26
+    require(bytes.size % stride == 0 && bytes.size / stride <= 64)
+    return bytes.indices.step(stride).map { offset ->
+      DhtContact(bytes.copyOfRange(offset, offset + 20).toByteString(),
+        endpoint(bytes.copyOfRange(offset + 20, offset + stride)))
+    }
+  }
+
+  fun compactNodes(nodes: List<DhtContact>): ByteArray {
+    require(nodes.size <= 8)
+    val output = Buffer()
+    for (node in nodes) output.write(node.id).write(compactEndpoint(node.endpoint))
+    return output.readByteArray()
+  }
+
+  fun compactEndpoint(endpoint: PeerEndpoint): ByteArray =
+    Buffer().write(requireNotNull(numericAddress(endpoint.host))).writeShort(endpoint.port)
+      .readByteArray()
+
+  fun endpoint(bytes: ByteArray): PeerEndpoint {
+    require(bytes.size == 6 || bytes.size == 18)
+    val port = ((bytes[bytes.size - 2].toInt() and 255) shl 8) or
+      (bytes.last().toInt() and 255)
+    require(port != 0)
+    return PeerEndpoint(numericHost(bytes.copyOfRange(0, bytes.size - 2)), port)
+  }
+
+  private fun encode(value: Map<String, Any>): ByteArray = Bencode.encode(value).also {
+    require(it.size <= MAX_SEND) { "DHT response exceeds packet limit" }
+  }
+}
+
+/** Parses literals only. Network-provided compact contacts never cause DNS lookups. */
+internal fun numericAddress(host: String): ByteArray? {
+  fun ipv4(value: String): ByteArray? {
+    val parts = value.split('.')
+    if (parts.size != 4) return null
+    val output = ByteArray(4)
+    for ((index, part) in parts.withIndex()) {
+      if (part.isEmpty() || part.any { it !in '0'..'9' } || part.length > 3) return null
+      val number = part.toIntOrNull() ?: return null
+      if (number !in 0..255) return null
+      output[index] = number.toByte()
+    }
+    return output
+  }
+  var value = host.removeSurrounding("[", "]")
+  if (':' !in value) return ipv4(value)
+  if ('.' in value) {
+    val tail = ipv4(value.substringAfterLast(':')) ?: return null
+    value = value.substringBeforeLast(':') + ":" +
+      (((tail[0].toInt() and 255) shl 8) or (tail[1].toInt() and 255)).toString(16) + ":" +
+      (((tail[2].toInt() and 255) shl 8) or (tail[3].toInt() and 255)).toString(16)
+  }
+  val halves = value.split("::")
+  if (halves.size > 2) return null
+  fun groups(part: String): List<Int>? {
+    if (part.isEmpty()) return emptyList()
+    return part.split(':').map { group ->
+      if (group.isEmpty() || group.length > 4 || group.any { it !in "0123456789abcdefABCDEF" }) {
+        return null
+      }
+      group.toInt(16)
+    }
+  }
+  val first = groups(halves[0]) ?: return null
+  val last = if (halves.size == 2) groups(halves[1]) ?: return null else emptyList()
+  val missing = 8 - first.size - last.size
+  if (halves.size == 1 && missing != 0 || halves.size == 2 && missing < 1) return null
+  val words = first + List(missing) { 0 } + last
+  return ByteArray(16) { index -> (words[index / 2] ushr (if (index % 2 == 0) 8 else 0)).toByte() }
+}
+
+internal fun dhtDistance(first: ByteString, second: ByteString): ByteString {
+  require(first.size == 20 && second.size == 20)
+  return ByteArray(20) { (first[it].toInt() xor second[it].toInt()).toByte() }.toByteString()
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtIdentity.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtIdentity.kt
@@ -1,0 +1,80 @@
+package com.linroid.ketch.torrent
+
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+
+/** BEP 42 node-ID prefix binding; the remaining 139 bits retain random entropy. */
+internal object DhtIdentity {
+  fun create(address: ByteArray, random: ByteArray = torrentRandomBytes(20)): ByteString {
+    require(random.size == 20)
+    val result = random.copyOf()
+    val crc = prefix(address, result[19].toInt() and 7)
+    result[0] = (crc ushr 24).toByte()
+    result[1] = (crc ushr 16).toByte()
+    result[2] = ((crc ushr 8 and 248) or (result[2].toInt() and 7)).toByte()
+    return result.toByteString()
+  }
+
+  fun valid(id: ByteString, address: ByteArray): Boolean {
+    if (id.size != 20 || (address.size != 4 && address.size != 16)) return false
+    val crc = prefix(address, id[19].toInt() and 7)
+    return id[0] == (crc ushr 24).toByte() && id[1] == (crc ushr 16).toByte() &&
+      (id[2].toInt() and 248) == (crc ushr 8 and 248)
+  }
+
+  private fun prefix(address: ByteArray, random: Int): Int {
+    require(address.size == 4 || address.size == 16)
+    val mask = if (address.size == 4) intArrayOf(3, 15, 63, 255)
+      else intArrayOf(1, 3, 7, 15, 31, 63, 127, 255)
+    val bytes = ByteArray(mask.size) { (address[it].toInt() and mask[it]).toByte() }
+    bytes[0] = (bytes[0].toInt() or (random shl 5)).toByte()
+    return crc32c(bytes)
+  }
+
+  internal fun crc32c(bytes: ByteArray): Int {
+    var value = -1
+    for (byte in bytes) {
+      value = value xor (byte.toInt() and 255)
+      repeat(8) { value = (value ushr 1) xor (if (value and 1 != 0) 0x82f63b78.toInt() else 0) }
+    }
+    return value.inv()
+  }
+}
+
+/** Ten-minute maximum validity; rotating secrets bind announce tokens to the requester's IP. */
+internal class DhtTokens(private val nowMs: () -> Long = monotonicClock()) {
+  private var epoch = nowMs() / 300_000
+  private var current = torrentRandomBytes(32)
+  private var previous: ByteArray? = null
+
+  fun issue(endpoint: PeerEndpoint): ByteArray {
+    rotate()
+    return token(current, endpoint)
+  }
+
+  fun valid(value: ByteArray, endpoint: PeerEndpoint): Boolean {
+    rotate()
+    if (value.size != 20) return false
+    return equal(value, token(current, endpoint)) ||
+      previous?.let { equal(value, token(it, endpoint)) } == true
+  }
+
+  private fun rotate() {
+    val next = nowMs() / 300_000
+    if (next != epoch) {
+      previous = if (next == epoch + 1) current else null
+      current = torrentRandomBytes(32)
+      epoch = next
+    }
+  }
+
+  private fun token(secret: ByteArray, endpoint: PeerEndpoint): ByteArray =
+    sha1Digest(secret + requireNotNull(numericAddress(endpoint.host)))
+
+  private fun equal(first: ByteArray, second: ByteArray): Boolean {
+    var difference = 0
+    for (index in first.indices) difference = difference or
+      (first[index].toInt() xor second[index].toInt())
+    return difference == 0
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRoutingTable.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRoutingTable.kt
@@ -1,0 +1,128 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+
+/** K=8 routing buckets containing only contacts that answered a correlated query. */
+internal class DhtRoutingTable(
+  val localId: ByteString,
+  private val nowMs: () -> Long = monotonicClock(),
+) {
+  private data class Entry(val contact: DhtContact, var seen: Long, var failures: Int = 0)
+  private data class Bucket(
+    val prefix: ByteString,
+    val depth: Int,
+    val entries: MutableList<Entry> = mutableListOf(),
+    var changed: Long = 0,
+  ) {
+    fun contains(id: ByteString): Boolean = (0 until depth).all { bit(prefix, it) == bit(id, it) }
+  }
+
+  private val mutex = Mutex()
+  private val buckets = mutableListOf(Bucket(ByteArray(20).toByteString(), 0))
+
+  init { require(localId.size == 20) }
+
+  /** Returns a questionable incumbent to ping; healthy incumbents are never displaced. */
+  suspend fun verified(contact: DhtContact): DhtContact? = mutex.withLock {
+    if (contact.id == localId) return@withLock null
+    while (true) {
+      val bucket = buckets.first { it.contains(contact.id) }
+      val existing = bucket.entries.firstOrNull { it.contact.id == contact.id }
+      if (existing != null) {
+        bucket.entries.remove(existing)
+        bucket.entries += Entry(contact, nowMs())
+        bucket.changed = nowMs()
+        return@withLock null
+      }
+      bucket.entries.removeAll { it.failures >= 2 }
+      if (bucket.entries.size < 8) {
+        bucket.entries += Entry(contact, nowMs())
+        bucket.changed = nowMs()
+        return@withLock null
+      }
+      if (bucket.contains(localId) && bucket.depth < 160) {
+        val right = bucket.prefix.toByteArray()
+        right[bucket.depth / 8] = (right[bucket.depth / 8].toInt() or
+          (128 ushr (bucket.depth % 8))).toByte()
+        val children = listOf(Bucket(bucket.prefix, bucket.depth + 1, changed = nowMs()),
+          Bucket(right.toByteString(), bucket.depth + 1, changed = nowMs()))
+        for (entry in bucket.entries) children.first { it.contains(entry.contact.id) }.entries += entry
+        buckets.remove(bucket)
+        buckets += children
+      } else {
+        return@withLock bucket.entries.filter { nowMs() - it.seen >= 900_000 }
+          .minByOrNull { it.seen }?.contact
+      }
+    }
+    @Suppress("UNREACHABLE_CODE")
+    null
+  }
+
+  suspend fun failed(contact: DhtContact) = mutex.withLock {
+    buckets.flatMap { it.entries }.firstOrNull { it.contact == contact }?.let { it.failures++ }
+  }
+
+  suspend fun seen(contact: DhtContact) = mutex.withLock {
+    buckets.first { it.contains(contact.id) }.let { bucket ->
+      bucket.entries.firstOrNull { it.contact == contact }?.let {
+        it.seen = nowMs()
+        bucket.changed = nowMs()
+      }
+    }
+  }
+
+  suspend fun closest(
+    target: ByteString,
+    count: Int = 8,
+    goodOnly: Boolean = false,
+  ): List<DhtContact> = mutex.withLock {
+    require(target.size == 20 && count in 1..64)
+    buckets.flatMap { it.entries }.filter {
+      it.failures < 2 && (!goodOnly || nowMs() - it.seen < 900_000)
+    }.map { it.contact }
+      .sortedBy { dhtDistance(it.id, target) }.take(count)
+  }
+
+  suspend fun refreshTargets(): List<ByteString> = mutex.withLock {
+    buckets.filter { nowMs() - it.changed >= 900_000 }.map { bucket ->
+      val target = torrentRandomBytes(20)
+      for (index in 0 until bucket.depth) {
+        val mask = 128 ushr (index % 8)
+        target[index / 8] = ((target[index / 8].toInt() and mask.inv()) or
+          (if (bit(bucket.prefix, index)) mask else 0)).toByte()
+      }
+      bucket.changed = nowMs()
+      target.toByteString()
+    }
+  }
+
+  suspend fun snapshot(): ByteArray = mutex.withLock {
+    Bencode.encode(mapOf("version" to 1L, "id" to localId.toByteArray(), "nodes" to
+      buckets.flatMap { it.entries }.filter { it.failures < 2 }.map {
+        mapOf("id" to it.contact.id.toByteArray(), "address" to DhtCodec.compactEndpoint(
+          it.contact.endpoint))
+      }))
+  }
+
+  companion object {
+    /** Persisted contacts are bootstrap candidates; they must answer again before insertion. */
+    fun restore(bytes: ByteArray): Pair<ByteString, List<DhtContact>> {
+      val root = Bencode.parse(bytes, 256 * 1024)
+      require(root["version"]?.integer == 1L)
+      val id = requireNotNull(root["id"]?.bytes).toByteString()
+      require(id.size == 20)
+      val nodes = requireNotNull(root["nodes"]?.list)
+      require(nodes.size <= 1280)
+      return id to nodes.map {
+        DhtContact(requireNotNull(it["id"]?.bytes).toByteString(),
+          DhtCodec.endpoint(requireNotNull(it["address"]?.bytes)))
+      }.distinct()
+    }
+
+    private fun bit(id: ByteString, index: Int): Boolean =
+      id[index / 8].toInt() and (128 ushr (index % 8)) != 0
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRpc.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRpc.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.text.CharacterCodingException
 
 /** One receive loop, bounded correlated queries, and bounded responses to unsolicited traffic. */
 internal class DhtRpc(
@@ -41,6 +42,8 @@ internal class DhtRpc(
           currentCoroutineContext().ensureActive()
           if (!packets.admitQuery(packet.remote.host)) continue
           val message = try { DhtCodec.parse(packet.bytes) } catch (_: IllegalArgumentException) {
+            continue
+          } catch (_: CharacterCodingException) {
             continue
           }
           if (message.type != "q") {

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRpc.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRpc.kt
@@ -1,0 +1,147 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import kotlin.coroutines.cancellation.CancellationException
+
+/** One receive loop, bounded correlated queries, and bounded responses to unsolicited traffic. */
+internal class DhtRpc(
+  private val socket: TorrentDatagramSocket,
+  private val scope: CoroutineScope,
+  private val onQuery: suspend (DhtMessage, PeerEndpoint) -> ByteArray?,
+  private val nowMs: () -> Long = monotonicClock(),
+) {
+  private data class Key(val endpoint: PeerEndpoint, val transaction: ByteString)
+  private val mutex = Mutex()
+  private val pending = mutableMapOf<Key, CompletableDeferred<DhtMessage>>()
+  private var receiver: Job? = null
+  private var closed = false
+  private val rate = DhtReplyQuota(nowMs)
+  private val packets = DhtReplyQuota(nowMs, queryLimit = 1000, sourceLimit = 200)
+
+  val local: PeerEndpoint get() = socket.local
+
+  fun start() {
+    check(receiver == null)
+    receiver = scope.launch {
+      try {
+        while (true) {
+          val packet = socket.receive()
+          currentCoroutineContext().ensureActive()
+          if (!packets.admitQuery(packet.remote.host)) continue
+          val message = try { DhtCodec.parse(packet.bytes) } catch (_: IllegalArgumentException) {
+            continue
+          }
+          if (message.type != "q") {
+            mutex.withLock {
+              pending[Key(packet.remote, message.transaction)]?.complete(message)
+            }
+          } else if (rate.admitQuery(packet.remote.host)) {
+            val reply = try { onQuery(message, packet.remote) } catch (e: CancellationException) {
+              throw e
+            } catch (_: Exception) {
+              DhtCodec.error(message.transaction, 203)
+            }
+            if (reply != null && reply.size <= DhtCodec.MAX_SEND &&
+              rate.admitReply(packet.remote.host, reply.size)) socket.send(packet.remote, reply)
+          }
+        }
+      } catch (e: Exception) {
+        currentCoroutineContext().ensureActive()
+        throw e
+      } finally {
+        withContext(NonCancellable) {
+          mutex.withLock {
+            closed = true
+            pending.values.forEach { it.cancel() }
+            pending.clear()
+          }
+        }
+      }
+    }
+  }
+
+  suspend fun query(
+    endpoint: PeerEndpoint,
+    name: String,
+    arguments: Map<String, Any>,
+    timeoutMs: Long = 5000,
+  ): DhtMessage? {
+    val numeric = requireNotNull(numericAddress(endpoint.host))
+    val remote = PeerEndpoint(numericHost(numeric), endpoint.port)
+    val transaction = torrentRandomBytes(8).toByteString()
+    val key = Key(remote, transaction)
+    val deferred = CompletableDeferred<DhtMessage>()
+    mutex.withLock {
+      check(!closed && receiver != null) { "DHT is not running" }
+      check(pending.size < 64) { "Too many outstanding DHT queries" }
+      check(key !in pending)
+      pending[key] = deferred
+    }
+    try {
+      socket.send(remote, DhtCodec.query(transaction, name, arguments))
+      return withTimeoutOrNull(timeoutMs) { deferred.await() }
+    } finally {
+      withContext(NonCancellable) { mutex.withLock { pending.remove(key) } }
+      deferred.cancel()
+    }
+  }
+
+  suspend fun close() {
+    receiver?.cancel()
+    socket.close()
+    withContext(NonCancellable) { receiver?.join() }
+  }
+}
+
+/** Fixed one-second windows cap both CPU work and reflection traffic; source maps are bounded. */
+internal class DhtReplyQuota(
+  private val nowMs: () -> Long,
+  private val queryLimit: Int = 100,
+  private val sourceLimit: Int = 20,
+) {
+  private var window = -1L
+  private var queries = 0
+  private var bytes = 0
+  private val sources = mutableMapOf<String, IntArray>()
+
+  fun admitQuery(host: String): Boolean {
+    rotate()
+    if (queries >= queryLimit || host !in sources && sources.size >= 128) return false
+    val source = sources.getOrPut(host) { IntArray(2) }
+    if (source[0] >= sourceLimit) return false
+    queries++
+    source[0]++
+    return true
+  }
+
+  fun admitReply(host: String, count: Int): Boolean {
+    rotate()
+    val source = sources[host] ?: return false
+    if (count < 0 || count > 4096 - source[1] || count > 65536 - bytes) return false
+    source[1] += count
+    bytes += count
+    return true
+  }
+
+  private fun rotate() {
+    val current = nowMs() / 1000
+    if (current != window) {
+      window = current
+      sources.clear()
+      queries = 0
+      bytes = 0
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtFoundationTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtFoundationTest.kt
@@ -1,0 +1,106 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.toByteString
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DhtFoundationTest {
+  @Test
+  fun nodeIdentity_matchesPublishedBep42VectorsAndCrc32cVector() {
+    val vectors = listOf(
+      "124.31.75.21" to "5fbfbff10c5d6a4ec8a88e4c6ab4c28b95eee401",
+      "21.75.31.124" to "5a3ce9c14e7a08645677bbd1cfe7d8f956d53256",
+      "65.23.51.170" to "a5d43220bc8f112a3d426c84764f8c2a1150e616",
+      "84.124.73.14" to "1b0321dd1bb1fe518101ceef99462b947a01ff41",
+      "43.213.53.83" to "e56f6cbf5b7c4be0237986d5243b87aa6d51305a"
+    )
+    for ((host, hex) in vectors) {
+      val address = assertNotNull(numericAddress(host))
+      assertTrue(DhtIdentity.valid(hex.decodeHex(), address))
+      val invalid = hex.decodeHex().toByteArray().also { it[0] = (it[0].toInt() xor 1).toByte() }
+      assertFalse(DhtIdentity.valid(invalid.toByteString(), address))
+    }
+    assertEquals(0xe3069283.toInt(), DhtIdentity.crc32c("123456789".encodeToByteArray()))
+    val ipv6 = assertNotNull(numericAddress("2001:4860:4860::8888"))
+    assertTrue(DhtIdentity.valid(DhtIdentity.create(ipv6), ipv6))
+  }
+
+  @Test
+  fun tokens_bindToIpAllowPortChangesAndExpireAcrossIdleWindows() {
+    var now = 0L
+    val tokens = DhtTokens { now }
+    val address = PeerEndpoint("127.0.0.1", 1)
+    val token = tokens.issue(address)
+    assertTrue(tokens.valid(token, address.copy(port = 2)))
+    assertFalse(tokens.valid(token, PeerEndpoint("127.0.0.2", 1)))
+    now = 300_000
+    assertTrue(tokens.valid(token, address))
+    now = 600_000
+    assertFalse(tokens.valid(token, address))
+    val next = tokens.issue(address)
+    now = 1_800_000
+    assertFalse(tokens.valid(next, address))
+  }
+
+  @Test
+  fun numericAddressesAndCompactContacts_preserveBothFamilies() {
+    assertContentEquals(ByteArray(15) + byteArrayOf(1), numericAddress("::1"))
+    assertNull(numericAddress("1::2::3"))
+    assertNull(numericAddress("999.1.2.3"))
+    assertNull(numericAddress("tracker.example"))
+    assertEquals(16, numericAddress("::ffff:192.0.2.1")?.size)
+    for (host in listOf("127.0.0.1", "0:0:0:0:0:0:0:1")) {
+      val node = DhtContact(ByteArray(20).toByteString(), PeerEndpoint(host, 6881))
+      assertEquals(listOf(node), DhtCodec.nodes(DhtCodec.compactNodes(listOf(node)), ':' in host))
+    }
+    assertFailsWith<IllegalArgumentException> { DhtCodec.nodes(ByteArray(27), false) }
+    assertFailsWith<IllegalArgumentException> { DhtCodec.parse(ByteArray(4097)) }
+  }
+
+  @Test
+  fun routing_splitsOwnRangeKeepsHealthyIncumbentsAndReplacesFailedOnes() = runTest {
+    var now = 0L
+    val table = DhtRoutingTable(ByteArray(20).toByteString()) { now }
+    fun node(value: Int) = DhtContact(ByteArray(20).also { it[0] = value.toByte() }.toByteString(),
+      PeerEndpoint("127.0.0.1", value + 1))
+    for (value in 128..135) table.verified(node(value))
+    assertNull(table.verified(node(136)))
+    assertEquals(8, table.closest(node(136).id).size)
+    assertFalse(node(136) in table.closest(node(136).id))
+    now = 900_000
+    val questionable = assertNotNull(table.verified(node(136)))
+    table.failed(questionable)
+    table.failed(questionable)
+    table.verified(node(136))
+    assertEquals(node(136), table.closest(node(136).id).first())
+    table.verified(node(1))
+    assertEquals(node(1), table.closest(node(1).id).first())
+    val restored = DhtRoutingTable.restore(table.snapshot())
+    assertEquals(9, restored.second.size)
+    assertEquals(table.localId, restored.first)
+    now += 900_000
+    assertTrue(table.refreshTargets().isNotEmpty())
+    assertTrue(table.refreshTargets().isEmpty())
+  }
+
+  @Test
+  fun responseQuota_boundsSourceAndGlobalReflectionTraffic() {
+    var now = 0L
+    val quota = DhtReplyQuota(nowMs = { now })
+    repeat(20) { assertTrue(quota.admitQuery("source")) }
+    assertFalse(quota.admitQuery("source"))
+    repeat(4) { assertTrue(quota.admitReply("source", 1024)) }
+    assertFalse(quota.admitReply("source", 1))
+    now = 1000
+    assertTrue(quota.admitQuery("source"))
+    assertTrue(quota.admitReply("source", 1024))
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtRpcTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtRpcTest.kt
@@ -1,0 +1,58 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.ByteString.Companion.toByteString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class DhtRpcTest {
+  @Test
+  fun ipv4_matchesTransactionAndEndpointAndTimesOutLostQueries() = runTest { exchange(false) }
+
+  @Test
+  fun ipv6_matchesTransactionAndEndpointAndTimesOutLostQueries() = runTest { exchange(true) }
+
+  private suspend fun exchange(ipv6: Boolean) = withContext(Dispatchers.Default) {
+    withTimeout(15_000) {
+      coroutineScope {
+        val network = createTorrentNetwork()
+        val host = if (ipv6) "::1" else "127.0.0.1"
+        val server = network.bindUdp(PeerEndpoint(host, 0))
+        val client = network.bindUdp(PeerEndpoint(host, 0))
+        val rpc = DhtRpc(client, this, onQuery = { _, _ -> null })
+        rpc.start()
+        try {
+          val reference = async {
+            val packet = server.receive()
+            val request = DhtCodec.parse(packet.bytes)
+            assertEquals("ping", request.query)
+            val spoofer = network.bindUdp(PeerEndpoint(host, 0))
+            try {
+              spoofer.send(packet.remote, DhtCodec.error(request.transaction, 201))
+            } finally {
+              spoofer.close()
+            }
+            server.send(packet.remote, DhtCodec.error(byteArrayOf(9).toByteString(), 201))
+            server.send(packet.remote, DhtCodec.response(request.transaction,
+              mapOf("id" to ByteArray(20) { 7 }), packet.remote))
+          }
+          val response = rpc.query(server.local, "ping", mapOf("id" to ByteArray(20)))
+          assertEquals("r", assertNotNull(response).type)
+          assertEquals(7.toByte(), response.body?.get("id")?.bytes?.first())
+          reference.await()
+          assertNull(rpc.query(server.local, "ping", mapOf("id" to ByteArray(20)), timeoutMs = 50))
+        } finally {
+          rpc.close()
+          network.close()
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtRpcTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtRpcTest.kt
@@ -40,6 +40,10 @@ class DhtRpcTest {
               spoofer.close()
             }
             server.send(packet.remote, DhtCodec.error(byteArrayOf(9).toByteString(), 201))
+            server.send(packet.remote, Bencode.encode(mapOf(
+              "t" to request.transaction.toByteArray(), "y" to byteArrayOf(-1),
+              "q" to "ping", "a" to mapOf("id" to ByteArray(20))
+            )))
             server.send(packet.remote, DhtCodec.response(request.transaction,
               mapOf("id" to ByteArray(20) { 7 }), packet.remote))
           }

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PosixTorrentNetwork.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PosixTorrentNetwork.ios.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import okio.IOException
 import platform.posix.AF_INET
 import platform.posix.AF_INET6
 import platform.posix.AF_UNSPEC
@@ -85,7 +86,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
       if (operations.load() == 0) dispose()
     }
     fun close() = lease.close()
-    fun checkOpen() = check(!closed.load()) { "Torrent socket closed" }
+    fun checkOpen() = ioCheck(!closed.load()) { "Torrent socket closed" }
 
     // Defer descriptor recycling until any in-flight nonblocking syscall returns.
     fun <T> operation(block: () -> T): T {
@@ -116,7 +117,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
         hints.ai_family = AF_UNSPEC
         hints.ai_socktype = type
         val result = alloc<CPointerVar<addrinfo>>()
-        check(getaddrinfo(endpoint.host, endpoint.port.toString(), hints.ptr, result.ptr) == 0) {
+        ioCheck(getaddrinfo(endpoint.host, endpoint.port.toString(), hints.ptr, result.ptr) == 0) {
           "Cannot resolve torrent endpoint"
         }
         val first = checkNotNull(result.value)
@@ -143,17 +144,17 @@ internal class PosixTorrentNetwork : TorrentNetwork {
 
   private fun create(family: Int, type: Int): Handle {
     val fd = socket(family, type, 0)
-    check(fd >= 0) { "Cannot create torrent socket: $errno" }
+    ioCheck(fd >= 0) { "Cannot create torrent socket: $errno" }
     return configure(fd)
   }
 
   private fun configure(fd: Int): Handle {
     try {
-      check(fcntl(fd, F_SETFL, O_NONBLOCK) == 0) { "Cannot set nonblocking socket" }
+      ioCheck(fcntl(fd, F_SETFL, O_NONBLOCK) == 0) { "Cannot set nonblocking socket" }
       memScoped {
         val enabled = alloc<IntVar>()
         enabled.value = 1
-        check(setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, enabled.ptr, sizeOf<IntVar>().toUInt()) == 0)
+        ioCheck(setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, enabled.ptr, sizeOf<IntVar>().toUInt()) == 0)
       }
     } catch (e: Throwable) {
       close(fd)
@@ -177,7 +178,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
           handle.operation { connect(handle.fd, pointer, size) }
         }
         if (status != 0) {
-          check(errno == EINPROGRESS || errno == EINTR) { "Torrent connect failed: $errno" }
+          ioCheck(errno == EINPROGRESS || errno == EINTR) { "Torrent connect failed: $errno" }
           while (true) {
             handle.checkOpen()
             val ready = memScoped {
@@ -196,8 +197,8 @@ internal class PosixTorrentNetwork : TorrentNetwork {
             val result = handle.operation {
               getsockopt(handle.fd, SOL_SOCKET, SO_ERROR, error.ptr, size.ptr)
             }
-            check(result == 0)
-            check(error.value == 0) { "Torrent connect failed: ${error.value}" }
+            ioCheck(result == 0)
+            ioCheck(error.value == 0) { "Torrent connect failed: ${error.value}" }
           }
         }
       }
@@ -215,8 +216,8 @@ internal class PosixTorrentNetwork : TorrentNetwork {
       val bound = address.use { pointer, size ->
         handle.operation { bind(handle.fd, pointer, size) }
       }
-      check(bound == 0)
-      check(handle.operation { listen(handle.fd, 64) } == 0)
+      ioCheck(bound == 0)
+      ioCheck(handle.operation { listen(handle.fd, 64) } == 0)
       return object : TorrentListener {
         override val local = localEndpoint(handle)
         override suspend fun accept(): TorrentConnection {
@@ -234,7 +235,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
                   val result = accepted.operation {
                     getpeername(fd, storage.ptr.reinterpret(), size.ptr)
                   }
-                  check(result == 0)
+                  ioCheck(result == 0)
                   endpoint(storage.ptr.reinterpret())
                 }
                 return connection(accepted, remote)
@@ -261,7 +262,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
       val bound = address.use { pointer, size ->
         handle.operation { bind(handle.fd, pointer, size) }
       }
-      check(bound == 0)
+      ioCheck(bound == 0)
       return object : TorrentDatagramSocket {
         override val local = localEndpoint(handle)
         override suspend fun send(remote: PeerEndpoint, bytes: ByteArray) {
@@ -278,7 +279,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
               }
             }
             if (written >= 0) {
-              check(written.toInt() == bytes.size) { "Short datagram write" }
+              ioCheck(written.toInt() == bytes.size) { "Short datagram write" }
               return
             }
             retry()
@@ -328,7 +329,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
           val count = bytes.usePinned {
             handle.operation { recv(handle.fd, it.addressOf(offset), (size - offset).toULong(), 0) }
           }
-          check(count != 0L) { "Torrent peer disconnected" }
+          ioCheck(count != 0L) { "Torrent peer disconnected" }
           if (count < 0) retry() else offset += count.toInt()
         }
         return bytes
@@ -344,7 +345,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
             }
           }
           if (count < 0) retry() else {
-            check(count > 0) { "Short torrent socket write" }
+            ioCheck(count > 0) { "Short torrent socket write" }
             offset += count.toInt()
           }
         }
@@ -354,7 +355,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
 
   private suspend fun retry() {
     val error = errno
-    check(error == EAGAIN || error == EWOULDBLOCK || error == EINTR) {
+    ioCheck(error == EAGAIN || error == EWOULDBLOCK || error == EINTR) {
       "Torrent socket I/O failed: $error"
     }
     delay(5)
@@ -364,7 +365,7 @@ internal class PosixTorrentNetwork : TorrentNetwork {
     val storage = alloc<sockaddr_storage>()
     val size = alloc<socklen_tVar>()
     size.value = sizeOf<sockaddr_storage>().toUInt()
-    check(handle.operation { getsockname(handle.fd, storage.ptr.reinterpret(), size.ptr) } == 0)
+    ioCheck(handle.operation { getsockname(handle.fd, storage.ptr.reinterpret(), size.ptr) } == 0)
     endpoint(storage.ptr.reinterpret())
   }
 
@@ -386,4 +387,11 @@ internal class PosixTorrentNetwork : TorrentNetwork {
   }
 
   override fun close() = resources.close()
+}
+
+private inline fun ioCheck(
+  value: Boolean,
+  message: () -> String = { "Torrent socket I/O failed" },
+) {
+  if (!value) throw IOException(message())
 }


### PR DESCRIPTION
Adds common Kotlin DHT message/contact codecs, separate routing-table instances with K=8 bucket splitting, freshness/failure handling and versioned bootstrap snapshots. Implements BEP 42 node-ID binding, CRC32C, rotating IP-bound announce tokens, and bounded endpoint/transaction-correlated RPC.

Inbound packet, query and response quotas bound parsing work and reflection traffic. Persisted nodes remain bootstrap candidates and must respond again before entering the live routing table.

Validation: all torrent tests pass on JVM, Android host and iOS simulator. Tests include published BEP 42 and CRC32C vectors, token rotation/IP binding, numeric IPv4/IPv6 encoding, routing replacement/persistence, quota bounds, and actual IPv4/IPv6 RPC with spoofed source/transaction replies and lost-query timeout.

Layer 10 of the approved stack, based on #156. Bootstrap, iterative lookup, announce, public-address validation and PEX follow in layer 11.
