### PR TITLE
feat(torrent): trackerless DHT and bounded peer exchange

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -14,8 +14,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 07 Tracker discovery | https://github.com/linroid/Ketch/pull/154 | Local HTTP parsing, IPv4/IPv6 UDP, tier and lifecycle validation |
 | 08 Swarm and upload | https://github.com/linroid/Ketch/pull/155 | Rarity/pipelines, complementary peers, recovery, upload policies and seeding lifecycle on JVM/Android/iOS |
 | 09 Magnet metadata | https://github.com/linroid/Ketch/pull/156 | Independent seeder metadata-to-payload transfer; common negotiation, hash/size/private validation and shared cache tests |
-| 10 DHT foundations | Pending PR | Published BEP 42/CRC vectors, routing/token expiry, packet quotas and IPv4/IPv6 RPC correlation |
-| 11–14 | Pending | Not implemented yet |
+| 10 DHT foundations | https://github.com/linroid/Ketch/pull/157 | Published BEP 42/CRC vectors, routing/token expiry, packet quotas and IPv4/IPv6 RPC correlation |
+| 11 Trackerless discovery and PEX | Pending PR | IPv4/IPv6 multi-hop/warm DHT, PEX payload discovery, public identity quorum, private-source policy; independent DHT-to-metadata-to-payload JVM transfer |
+| 12–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtNode.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtNode.kt
@@ -1,0 +1,265 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/** One address-family DHT. Only correlated, validated respondents enter the routing table. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class DhtNode(
+  socket: TorrentDatagramSocket,
+  scope: CoroutineScope,
+  id: ByteString? = null,
+  private val allowLocalAddresses: Boolean = false,
+  private val queryTimeoutMs: Long = 5000,
+  private val nowMs: () -> Long = monotonicClock(),
+) {
+  private val ipv6 = ':' in socket.local.host
+  private val routingState = AtomicReference(DhtRoutingTable(id ?: run {
+    val address = numericAddress(socket.local.host)!!
+    if (publicTorrentAddress(address)) DhtIdentity.create(address)
+    else torrentRandomBytes(20).toByteString()
+  }, nowMs, enforceDiversity = !allowLocalAddresses))
+  private val routing: DhtRoutingTable get() = routingState.load()
+  private val voteMutex = Mutex()
+  private val votes = linkedMapOf<ByteString, MutableSet<ByteString>>()
+  private var voteWindow = nowMs()
+  private var externalAddress: ByteString? = null
+  private val tokens = DhtTokens(nowMs)
+  private val stored = linkedMapOf<ByteString, LinkedHashMap<PeerEndpoint, Long>>()
+  private val lookups = Semaphore(4)
+  private val rpc = DhtRpc(socket, scope, ::handle, nowMs)
+  private val bootstrapMutex = Mutex()
+  private val bootstrapCandidates = linkedSetOf<PeerEndpoint>()
+
+  val local: PeerEndpoint get() = rpc.local
+
+  fun start() = rpc.start()
+
+  suspend fun close() = rpc.close()
+
+  suspend fun snapshot(): ByteArray = routing.snapshot()
+
+  suspend fun bootstrap(endpoints: List<PeerEndpoint>) = bootstrapMutex.withLock {
+    for (endpoint in endpoints.take(64)) {
+      if (validEndpoint(endpoint)) bootstrapCandidates += canonical(endpoint)
+    }
+    while (bootstrapCandidates.size > 64) bootstrapCandidates.remove(bootstrapCandidates.first())
+    coroutineScope {
+      bootstrapCandidates.toList().chunked(3).forEach { batch ->
+        batch.map { endpoint -> async { ask(endpoint, "ping", emptyMap()) } }.awaitAll()
+      }
+    }
+    lookup(routing.localId, announcePort = null, peers = false)
+  }
+
+  suspend fun peers(hash: InfoHash, announcePort: Int? = null): List<PeerEndpoint> =
+    lookups.withPermit { lookup(hash.toBytes().toByteString(), announcePort, peers = true) }
+
+  suspend fun refresh() {
+    for (target in routing.refreshTargets().take(16)) {
+      lookups.withPermit { lookup(target, announcePort = null, peers = false) }
+    }
+  }
+
+  private suspend fun lookup(
+    target: ByteString,
+    announcePort: Int?,
+    peers: Boolean,
+  ): List<PeerEndpoint> = coroutineScope {
+    val candidates = linkedMapOf<ByteString, DhtContact>()
+    routing.closest(target, 32).forEach { candidates[it.id] = it }
+    val queried = mutableSetOf<PeerEndpoint>()
+    val found = linkedSetOf<PeerEndpoint>()
+    val announcements = mutableMapOf<DhtContact, ByteArray>()
+    for (round in 0 until 32) {
+      currentCoroutineContext().ensureActive()
+      val batch = candidates.values.sortedBy { dhtDistance(it.id, target) }
+        .filter { it.endpoint !in queried }.take(3)
+      if (batch.isEmpty()) break
+      queried += batch.map { it.endpoint }
+      val replies = batch.map { contact -> async {
+        val arguments = mapOf<String, Any>((if (peers) "info_hash" else "target") to
+          target.toByteArray(), "want" to listOf(if (ipv6) "n6" else "n4"))
+        contact to ask(contact.endpoint, if (peers) "get_peers" else "find_node", arguments,
+          expected = contact.id)
+      } }.awaitAll()
+      for ((contact, reply) in replies) {
+        val body = reply?.body ?: continue
+        val nodes = body[if (ipv6) "nodes6" else "nodes"]?.bytes?.let {
+          runCatching { DhtCodec.nodes(it, ipv6) }.getOrDefault(emptyList())
+        }.orEmpty()
+        for (node in nodes) {
+          if (validContact(node) && candidates.size < 256) candidates[node.id] = node
+        }
+        body["values"]?.list?.take(64)?.forEach { value ->
+          val endpoint = value.bytes?.let { runCatching { DhtCodec.endpoint(it) }.getOrNull() }
+          if (endpoint != null && validEndpoint(endpoint) && found.size < 1024) found += endpoint
+        }
+        body["token"]?.bytes?.let { token ->
+          if (token.size in 1..64) announcements[contact] = token
+        }
+      }
+    }
+    if (announcePort != null) {
+      require(announcePort in 1..65535)
+      announcements.entries.sortedBy { dhtDistance(it.key.id, target) }.take(8).chunked(3)
+        .forEach { batch ->
+          batch.map { (contact, token) -> async {
+            ask(contact.endpoint, "announce_peer", mapOf("info_hash" to target.toByteArray(),
+              "port" to announcePort.toLong(), "token" to token, "implied_port" to 0L), contact.id)
+          } }.awaitAll()
+        }
+    }
+    found.toList()
+  }
+
+  private suspend fun ask(
+    endpoint: PeerEndpoint,
+    method: String,
+    arguments: Map<String, Any>,
+    expected: ByteString? = null,
+  ): DhtMessage? {
+    if (!validEndpoint(endpoint)) return null
+    val remote = canonical(endpoint)
+    try {
+      val response = rpc.query(remote, method, arguments + ("id" to routing.localId.toByteArray()),
+        queryTimeoutMs)
+      if (response != null) observeAddress(response, remote)
+      if (response?.type != "r") {
+        if (expected != null) routing.failed(DhtContact(expected, remote))
+        return null
+      }
+      val id = requireNotNull(response.body?.get("id")?.bytes).toByteString()
+      val contact = DhtContact(id, remote)
+      if (expected != null && expected != id || !validContact(contact)) return null
+      val incumbent = routing.verified(contact)
+      if (incumbent != null && method != "ping") {
+        ask(incumbent.endpoint, "ping", emptyMap(), incumbent.id)
+        routing.verified(contact)
+      }
+      return response
+    } catch (e: CancellationException) {
+      throw e
+    } catch (_: Exception) {
+      if (expected != null) routing.failed(DhtContact(expected, remote))
+      return null
+    }
+  }
+
+
+  /** Require matching reports from three different network prefixes before changing identity. */
+  private suspend fun observeAddress(response: DhtMessage, remote: PeerEndpoint) {
+    if (allowLocalAddresses) return
+    val compact = response.root["ip"]?.bytes ?: return
+    val observed = runCatching { DhtCodec.endpoint(compact) }.getOrNull() ?: return
+    if (!validEndpoint(observed)) return
+    val address = numericAddress(observed.host)!!.toByteString()
+    val voter = numericAddress(remote.host)!!.copyOf(if (ipv6) 8 else 3).toByteString()
+    voteMutex.withLock {
+      if (address == externalAddress) return@withLock
+      if (nowMs() - voteWindow >= 600_000) {
+        votes.clear()
+        voteWindow = nowMs()
+      }
+      if (address !in votes && votes.size >= 16) votes.remove(votes.keys.first())
+      val reporters = votes.getOrPut(address) { mutableSetOf() }
+      reporters += voter
+      if (reporters.size < 3) return@withLock
+      val previous = routing
+      val updated = DhtRoutingTable(DhtIdentity.create(address.toByteArray()), nowMs,
+        enforceDiversity = !allowLocalAddresses)
+      for (contact in previous.closest(previous.localId, 64)) updated.verified(contact)
+      routingState.store(updated)
+      externalAddress = address
+      votes.clear()
+    }
+  }
+
+  /** Called serially by the RPC receiver; never waits for another RPC. */
+  private suspend fun handle(message: DhtMessage, remote: PeerEndpoint): ByteArray? {
+    if (!validEndpoint(remote)) return null
+    val body = requireNotNull(message.body)
+    val sender = DhtContact(requireNotNull(body["id"]?.bytes).toByteString(), remote)
+    if (validContact(sender)) routing.seen(sender)
+    val values = mutableMapOf<String, Any>("id" to routing.localId.toByteArray())
+    when (message.query) {
+      "ping" -> Unit
+      "find_node", "get_peers" -> {
+        val target = requireNotNull(body[if (message.query == "get_peers") "info_hash" else "target"]
+          ?.bytes).toByteString()
+        require(target.size == 20)
+        val nodes = routing.closest(target, goodOnly = true)
+        values[if (ipv6) "nodes6" else "nodes"] = DhtCodec.compactNodes(nodes)
+        if (message.query == "get_peers") {
+          values["token"] = tokens.issue(remote)
+          val entries = stored[target]
+          entries?.entries?.removeAll { nowMs() - it.value >= 1_800_000 }
+          if (!entries.isNullOrEmpty()) {
+            values.remove(if (ipv6) "nodes6" else "nodes")
+            values["values"] = entries.keys.take(if (ipv6) 32 else 64)
+              .map(DhtCodec::compactEndpoint)
+          }
+        }
+      }
+      "announce_peer" -> {
+        require(validContact(sender)) { "Invalid announcing node" }
+        require(tokens.valid(requireNotNull(body["token"]?.bytes), remote)) { "Invalid DHT token" }
+        val hash = requireNotNull(body["info_hash"]?.bytes).toByteString()
+        require(hash.size == 20)
+        val port = if (body["implied_port"]?.integer == 1L) remote.port.toLong()
+          else requireNotNull(body["port"]?.integer)
+        require(port in 1..65535)
+        if (hash !in stored && stored.size >= 128) stored.remove(stored.keys.first())
+        val entries = stored.getOrPut(hash) { linkedMapOf() }
+        val endpoint = remote.copy(port = port.toInt())
+        entries.remove(endpoint)
+        if (entries.size >= 64) entries.remove(entries.keys.first())
+        entries[endpoint] = nowMs()
+      }
+      else -> return DhtCodec.error(message.transaction, 204)
+    }
+    return DhtCodec.response(message.transaction, values, remote)
+  }
+
+  private fun validContact(contact: DhtContact): Boolean = validEndpoint(contact.endpoint) &&
+    (allowLocalAddresses || DhtIdentity.valid(contact.id, numericAddress(contact.endpoint.host)!!))
+
+  private fun validEndpoint(endpoint: PeerEndpoint): Boolean {
+    val address = numericAddress(endpoint.host) ?: return false
+    return endpoint.port != 0 && (address.size == 16) == ipv6 &&
+      (allowLocalAddresses || publicTorrentAddress(address))
+  }
+
+  private fun canonical(endpoint: PeerEndpoint): PeerEndpoint =
+    endpoint.copy(host = numericHost(requireNotNull(numericAddress(endpoint.host))))
+}
+
+internal fun publicTorrentAddress(address: ByteArray): Boolean {
+  if (address.size == 16) {
+    return address[0].toInt() and 224 == 32 &&
+      !(address[0] == 0x20.toByte() && address[1] == 1.toByte() &&
+        address[2] == 0x0d.toByte() && address[3] == 0xb8.toByte())
+  }
+  if (address.size != 4) return false
+  val a = address[0].toInt() and 255
+  val b = address[1].toInt() and 255
+  val c = address[2].toInt() and 255
+  return a !in listOf(0, 10, 127) && a < 224 && !(a == 100 && b in 64..127) &&
+    !(a == 169 && b == 254) && !(a == 172 && b in 16..31) &&
+    !(a == 192 && (b == 168 || b == 0 && c in listOf(0, 2))) &&
+    !(a == 198 && (b in 18..19 || b == 51 && c == 100)) &&
+    !(a == 203 && b == 0 && c == 113)
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRoutingTable.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/DhtRoutingTable.kt
@@ -9,6 +9,7 @@ import okio.ByteString.Companion.toByteString
 internal class DhtRoutingTable(
   val localId: ByteString,
   private val nowMs: () -> Long = monotonicClock(),
+  private val enforceDiversity: Boolean = false,
 ) {
   private data class Entry(val contact: DhtContact, var seen: Long, var failures: Int = 0)
   private data class Bucket(
@@ -30,6 +31,16 @@ internal class DhtRoutingTable(
     if (contact.id == localId) return@withLock null
     while (true) {
       val bucket = buckets.first { it.contains(contact.id) }
+      if (enforceDiversity) {
+        val address = requireNotNull(numericAddress(contact.endpoint.host))
+        val prefix = address.copyOf(if (address.size == 4) 3 else 8).toByteString()
+        val sameNetwork = bucket.entries.count {
+          val other = requireNotNull(numericAddress(it.contact.endpoint.host))
+          it.contact.id != contact.id && other.size == address.size &&
+            other.copyOf(if (other.size == 4) 3 else 8).toByteString() == prefix
+        }
+        if (sameNetwork >= 2) return@withLock null
+      }
       val existing = bucket.entries.firstOrNull { it.contact.id == contact.id }
       if (existing != null) {
         bucket.entries.remove(existing)

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerExchange.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/PeerExchange.kt
@@ -1,0 +1,101 @@
+package com.linroid.ketch.torrent
+
+import okio.Buffer
+
+internal data class PexUpdate(val added: List<PeerEndpoint>, val dropped: List<PeerEndpoint>)
+
+/** Per-peer BEP 11 receive policy. Exchange data is a bounded, untrusted discovery hint. */
+internal class PeerExchange(private val nowMs: () -> Long = monotonicClock()) {
+  private var receivedAt: Long? = null
+  private var sentAt: Long? = null
+  private val advertised = linkedSetOf<PeerEndpoint>()
+
+  fun receive(bytes: ByteArray): PexUpdate {
+    val now = nowMs()
+    require(receivedAt == null || now - receivedAt!! >= 60_000) { "Peer exchange rate exceeded" }
+    val root = Bencode.parse(bytes, 16 * 1024)
+    val keys = listOf("added", "added6", "dropped", "dropped6")
+    require(root.dictionary != null && keys.any { root[it] != null })
+    fun peers(key: String, ipv6: Boolean): List<PeerEndpoint> {
+      val raw = root[key]?.bytes ?: return emptyList()
+      require(raw.size / (if (ipv6) 18 else 6) <= 200)
+      val peers = TorrentTracker.compactPeers(raw, ipv6)
+      root["$key.f"]?.let { require(it.bytes?.size == raw.size / (if (ipv6) 18 else 6)) }
+      return peers
+    }
+    val added = peers("added", false) + peers("added6", true)
+    val dropped = peers("dropped", false) + peers("dropped6", true)
+    require(added.size <= (if (receivedAt == null) 200 else 50) && dropped.size <= 50)
+    require(added.none { it in dropped })
+    receivedAt = now
+    return PexUpdate(added.distinctBy { it.host }, dropped.distinct())
+  }
+
+  fun due(): Boolean = sentAt?.let { nowMs() - it >= 60_000 } ?: true
+
+  /** Only fully handshaken live connections belong in this snapshot. */
+  fun message(remoteId: Int, connected: Set<PeerEndpoint>): PeerMessage.Extended? {
+    if (remoteId == 0 || sentAt?.let { nowMs() - it < 60_000 } == true) return null
+    val dropped = advertised.filter { it !in connected }.take(50)
+    val added = connected.filter { it !in advertised && numericAddress(it.host) != null }.take(50)
+    if (added.isEmpty() && dropped.isEmpty()) return null
+    val values = mutableMapOf<String, Any>()
+    for ((name, peers) in listOf("added" to added, "dropped" to dropped)) {
+      for (ipv6 in listOf(false, true)) {
+        val family = peers.filter { (':' in it.host) == ipv6 }
+        if (family.isNotEmpty()) {
+          val key = name + if (ipv6) "6" else ""
+          val compact = Buffer()
+          family.forEach { compact.write(DhtCodec.compactEndpoint(it)) }
+          values[key] = compact.readByteArray()
+          if (name == "added") values["$key.f"] = ByteArray(family.size) { 0x10 }
+        }
+      }
+    }
+    advertised.removeAll(dropped.toSet())
+    advertised.addAll(added)
+    sentAt = nowMs()
+    return PeerMessage.Extended(remoteId, Bencode.encode(values))
+  }
+}
+
+internal enum class PeerOrigin { TRACKER, DHT, PEX, EXPLICIT }
+
+/** Tracks provenance and removes only the departing source's claim on a candidate. */
+internal class TorrentPeerDirectory(private val privateTorrent: Boolean) {
+  private data class Source(val origin: PeerOrigin, val identity: String)
+  private val peers = linkedMapOf<PeerEndpoint, MutableSet<Source>>()
+  private var tracker: String? = null
+
+  fun update(
+    origin: PeerOrigin,
+    identity: String,
+    added: List<PeerEndpoint>,
+    dropped: List<PeerEndpoint> = emptyList(),
+  ): Boolean {
+    if (privateTorrent && origin != PeerOrigin.TRACKER) return false
+    var switched = false
+    if (privateTorrent && tracker != identity) {
+      switched = tracker != null
+      peers.clear()
+      tracker = identity
+    }
+    val source = Source(origin, identity)
+    for (endpoint in dropped) {
+      peers[endpoint]?.let { it.remove(source); if (it.isEmpty()) peers.remove(endpoint) }
+    }
+    val limit = if (origin == PeerOrigin.PEX) 50 else 256
+    val existing = peers.count { source in it.value }
+    var remaining = (limit - existing).coerceAtLeast(0)
+    for (endpoint in added) {
+      if (remaining == 0 || peers.size >= 4096) break
+      if (endpoint.port == 0) continue
+      if (origin == PeerOrigin.PEX && peers.keys.any { it.host == endpoint.host }) continue
+      val sources = peers.getOrPut(endpoint) { mutableSetOf() }
+      if (sources.size < 8 && sources.add(source)) remaining--
+    }
+    return switched
+  }
+
+  fun candidates(): List<PeerEndpoint> = peers.keys.toList()
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentDns.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentDns.kt
@@ -1,0 +1,4 @@
+package com.linroid.ketch.torrent
+
+/** Resolves all available address families; protocol parsers themselves never perform DNS. */
+internal expect suspend fun resolveTorrentHost(host: String): List<ByteArray>

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import okio.IOException
@@ -33,8 +35,11 @@ internal class TorrentSwarm(
   private val uploadPayload: suspend (Int) -> Unit = {},
   private val onProgress: suspend (Long) -> Unit = {},
   private val onCompleted: suspend () -> Unit = {},
+  private val allowLocalDiscovery: Boolean = false,
 ) {
   private val uploadSlots = Semaphore(4)
+  private val connectedMutex = Mutex()
+  private val connected = mutableMapOf<Int, PeerEndpoint>()
 
   /** A closed peer stream fails once every candidate has exhausted its bounded retries. */
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
@@ -58,6 +63,8 @@ internal class TorrentSwarm(
     val pending = ArrayDeque<PeerEndpoint>()
     val results = Channel<Pair<PeerEndpoint, Throwable?>>(512)
     val progressEvents = Channel<Unit>(Channel.CONFLATED)
+    val pexEvents = Channel<Pair<PeerEndpoint, PexUpdate>>(64)
+    val pexDirectory = TorrentPeerDirectory(store.metadata.isPrivate)
     val retryAt = mutableMapOf<PeerEndpoint, Long>()
     val now = monotonicClock()
     var discoveryClosed = false
@@ -91,13 +98,16 @@ internal class TorrentSwarm(
           active[endpoint] = launch(Dispatchers.Default) {
             var failure: Throwable? = null
             try {
-              peer(id, endpoint, scheduler, progressEvents)
+              peer(id, endpoint, scheduler, progressEvents, pexEvents)
             } catch (e: CancellationException) {
               throw e
             } catch (e: Exception) {
               failure = e
             } finally {
-              withContext(NonCancellable) { scheduler.remove(id) }
+              withContext(NonCancellable) {
+                scheduler.remove(id)
+                connectedMutex.withLock { connected.remove(id) }
+              }
               overhead.close()
               results.trySend(endpoint to failure)
             }
@@ -123,6 +133,14 @@ internal class TorrentSwarm(
               pending.addLast(endpoint)
             }
           }
+          pexEvents.onReceive { (source, update) ->
+            pexDirectory.update(PeerOrigin.PEX, "${source.host}:${source.port}", update.added,
+              update.dropped)
+            for (endpoint in pexDirectory.candidates()) {
+              if (endpoint !in attempts && endpoint !in pending &&
+                attempts.size + pending.size < 4096) pending.addLast(endpoint)
+            }
+          }
           progressEvents.onReceive { onProgress(store.progress().sum()) }
           onTimeout(100) {}
         }
@@ -132,6 +150,7 @@ internal class TorrentSwarm(
       active.values.forEach { it.join() }
       results.close()
       progressEvents.close()
+      pexEvents.close()
     }
   }
 
@@ -141,6 +160,7 @@ internal class TorrentSwarm(
     endpoint: PeerEndpoint,
     scheduler: TorrentPieceScheduler,
     progressEvents: SendChannel<Unit>,
+    pexEvents: SendChannel<Pair<PeerEndpoint, PexUpdate>>,
   ) =
     supervisorScope {
       val connection = network.connect(endpoint)
@@ -150,10 +170,12 @@ internal class TorrentSwarm(
         val wire = PeerWire(connection, store.metadata)
         val handshake = wire.handshake(PeerHandshake(store.metadata.infoHash, peerId, true, false))
         require(!handshake.peerId.contentEquals(peerId)) { "Connected to ourselves" }
+        connectedMutex.withLock { connected[id] = connection.remote }
+        val exchange = PeerExchange()
         val extensions = PeerExtensions()
         var metadataServed = 0
         var metadataWindow = TimeSource.Monotonic.markNow()
-        if (handshake.extensions) wire.send(PeerExtensions.handshake(store.metadata))
+        if (handshake.extensions) wire.send(PeerExtensions.handshake(store.metadata, pex = !store.metadata.isPrivate))
         val state = PeerProtocolState(store.pieceCount, maxPending = 16)
         val advertised = store.verifiedPieces()
         var version = -1L
@@ -253,6 +275,14 @@ internal class TorrentSwarm(
                         wire.send(response)
                       }
                     }
+                  } else if (message.id == PeerExtensions.PEX) {
+                    require(!store.metadata.isPrivate) { "Private torrent peer exchange is forbidden" }
+                    val update = exchange.receive(message.payload)
+                    val added = update.added.filter { peer ->
+                      allowLocalDiscovery ||
+                        numericAddress(peer.host)?.let(::publicTorrentAddress) == true
+                    }
+                    pexEvents.send(connection.remote to update.copy(added = added))
                   }
                 }
                 else -> Unit
@@ -263,6 +293,12 @@ internal class TorrentSwarm(
               uploadSlots.tryAcquire()) {
               uploadSlot = true
               wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+            }
+            if (!store.metadata.isPrivate && extensions.id("ut_pex") != 0 && exchange.due()) {
+              val contacts = connectedMutex.withLock { connected.values.toSet() }
+                .filter { it != connection.remote && (allowLocalDiscovery ||
+                  numericAddress(it.host)?.let(::publicTorrentAddress) == true) }.toSet()
+              exchange.message(extensions.id("ut_pex"), contacts)?.let { wire.send(it) }
             }
             scheduler.snapshot(version)?.let { (nextVersion, pieces) ->
               version = nextVersion

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -70,8 +70,21 @@ internal class TorrentSwarm(
     var discoveryClosed = false
     var complete = false
     var nextId = 0
+    fun acceptPex(source: PeerEndpoint, update: PexUpdate) {
+    pexDirectory.update(PeerOrigin.PEX, "${source.host}:${source.port}", update.added,
+      update.dropped)
+    for (endpoint in pexDirectory.candidates()) {
+      if (endpoint !in attempts && endpoint !in pending &&
+        attempts.size + pending.size < 4096) pending.addLast(endpoint)
+    }
+    }
     try {
       while (currentCoroutineContext().isActive) {
+        // A terminating introducer may have queued its last PEX before its result was selected.
+        repeat(64) {
+          val event = pexEvents.tryReceive().getOrNull() ?: return@repeat
+          acceptPex(event.first, event.second)
+        }
         if (store.completed() && !complete) {
           store.finish()
           onProgress(store.progress().sum())
@@ -133,14 +146,7 @@ internal class TorrentSwarm(
               pending.addLast(endpoint)
             }
           }
-          pexEvents.onReceive { (source, update) ->
-            pexDirectory.update(PeerOrigin.PEX, "${source.host}:${source.port}", update.added,
-              update.dropped)
-            for (endpoint in pexDirectory.candidates()) {
-              if (endpoint !in attempts && endpoint !in pending &&
-                attempts.size + pending.size < 4096) pending.addLast(endpoint)
-            }
-          }
+          pexEvents.onReceive { (source, update) -> acceptPex(source, update) }
           progressEvents.onReceive { onProgress(store.progress().sum()) }
           onTimeout(100) {}
         }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentTracker.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentTracker.kt
@@ -215,15 +215,24 @@ internal class TrackerTiers(
 ) {
   private val tiers = tiers.map { it.distinct().shuffled().toMutableList() }
   private val ids = mutableMapOf<String, ByteArray>()
+  private var preferCurrent = false
+  private var current: String? = null
+
+  fun preferCurrentTracker() { preferCurrent = true }
 
   suspend fun announce(request: TrackerAnnounce): TrackerResponse {
-    for (tier in tiers) {
+    val ordered = if (preferCurrent && current != null) {
+      listOf(listOf(current!!)) + tiers.map { tier -> tier.filter { it != current } }
+    } else tiers
+    for (tier in ordered) {
       for (url in tier.toList()) {
         try {
           val result = announce(url, request, ids[url])
           result.trackerId?.let { ids[url] = it }
-          tier.remove(url)
-          tier.add(0, url)
+          val original = tiers.first { url in it }
+          original.remove(url)
+          original.add(0, url)
+          current = url
           return result.copy(source = url)
         } catch (_: TimeoutCancellationException) {
           currentCoroutineContext().ensureActive()

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TrackerDiscovery.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TrackerDiscovery.kt
@@ -11,6 +11,8 @@ internal class TrackerDiscovery(
   private val onPrivateTrackerChanged: suspend () -> Unit = {},
   private val nowMs: () -> Long = monotonicClock(),
 ) {
+  init { if (metadata.isPrivate) trackers.preferCurrentTracker() }
+
   private var nextAnnounce = 0L
   private var started = false
   private var completed = false

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtExternalIdentityTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtExternalIdentityTest.kt
@@ -1,0 +1,39 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
+import okio.ByteString.Companion.toByteString
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DhtExternalIdentityTest {
+  @Test
+  fun externalIdentity_requiresThreeIndependentNetworkReports() = runTest {
+    val observed = PeerEndpoint("8.8.4.4", 6881)
+    val packets = Channel<TorrentDatagram>(64)
+    val socket = object : TorrentDatagramSocket {
+      override val local = PeerEndpoint("0.0.0.0", 6881)
+      override suspend fun send(remote: PeerEndpoint, bytes: ByteArray) {
+        val query = DhtCodec.parse(bytes)
+        val id = DhtIdentity.create(numericAddress(remote.host)!!)
+        val body = mapOf("id" to id.toByteArray(), "nodes" to ByteArray(0))
+        packets.send(TorrentDatagram(remote, DhtCodec.response(query.transaction, body, observed)))
+      }
+      override suspend fun receive(): TorrentDatagram = packets.receive()
+      override fun close() { packets.close() }
+    }
+    val node = DhtNode(socket, backgroundScope, id = ByteArray(20).toByteString())
+    node.start()
+    try {
+      node.bootstrap(listOf(PeerEndpoint("1.1.1.1", 6881), PeerEndpoint("9.9.9.9", 6881)))
+      assertFalse(DhtIdentity.valid(DhtRoutingTable.restore(node.snapshot()).first,
+        numericAddress(observed.host)!!))
+      node.bootstrap(listOf(PeerEndpoint("8.8.8.8", 6881)))
+      assertTrue(DhtIdentity.valid(DhtRoutingTable.restore(node.snapshot()).first,
+        numericAddress(observed.host)!!))
+    } finally {
+      node.close()
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtFoundationTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtFoundationTest.kt
@@ -68,7 +68,7 @@ class DhtFoundationTest {
   @Test
   fun routing_splitsOwnRangeKeepsHealthyIncumbentsAndReplacesFailedOnes() = runTest {
     var now = 0L
-    val table = DhtRoutingTable(ByteArray(20).toByteString()) { now }
+    val table = DhtRoutingTable(ByteArray(20).toByteString(), nowMs = { now })
     fun node(value: Int) = DhtContact(ByteArray(20).also { it[0] = value.toByte() }.toByteString(),
       PeerEndpoint("127.0.0.1", value + 1))
     for (value in 128..135) table.verified(node(value))

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtNodeTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/DhtNodeTest.kt
@@ -1,0 +1,57 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DhtNodeTest {
+  @Test
+  fun ipv4_coldBootstrapAnnounceLookupAndWarmRestore() = runTest { discover(false) }
+
+  @Test
+  fun ipv6_coldBootstrapAnnounceLookupAndWarmRestore() = runTest { discover(true) }
+
+  private suspend fun discover(ipv6: Boolean) = withContext(Dispatchers.Default) {
+    withTimeout(20_000) {
+      coroutineScope {
+        val network = createTorrentNetwork()
+        val host = if (ipv6) "::1" else "127.0.0.1"
+        suspend fun node() = DhtNode(network.bindUdp(PeerEndpoint(host, 0)), this,
+          allowLocalAddresses = true, queryTimeoutMs = 500).also { it.start() }
+        val router = node()
+        val announcer = node()
+        val seeker = node()
+        val middle = node()
+        try {
+          val hash = InfoHash.fromBytes(torrentRandomBytes(20))
+          announcer.bootstrap(listOf(router.local))
+          announcer.peers(hash, announcePort = 6881)
+          middle.bootstrap(listOf(router.local))
+          seeker.bootstrap(listOf(middle.local))
+          val found = seeker.peers(hash)
+          assertEquals(listOf(PeerEndpoint(if (ipv6) "0:0:0:0:0:0:0:1" else host, 6881)), found)
+          val restored = DhtRoutingTable.restore(seeker.snapshot())
+          assertTrue(restored.second.isNotEmpty())
+          val warm = node()
+          try {
+            warm.bootstrap(restored.second.map { it.endpoint })
+            assertEquals(found, warm.peers(hash))
+          } finally {
+            warm.close()
+          }
+        } finally {
+          middle.close()
+          seeker.close()
+          announcer.close()
+          router.close()
+          network.close()
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerExchangeTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/PeerExchangeTest.kt
@@ -1,0 +1,83 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PeerExchangeTest {
+  @Test
+  fun updates_onlyAdvertiseConnectedPeersAndSendDropsAfterInterval() {
+    var now = 0L
+    val sender = PeerExchange { now }
+    val receiver = PeerExchange { now }
+    val first = PeerEndpoint("1.2.3.4", 6881)
+    val second = PeerEndpoint("2001:4860:0:0:0:0:0:1", 6881)
+    val message = sender.message(7, setOf(first, second))!!
+    assertEquals(7, message.id)
+    assertEquals(setOf(first, second), receiver.receive(message.payload).added.toSet())
+    assertNull(sender.message(7, emptySet()))
+    assertFailsWith<IllegalArgumentException> { receiver.receive(message.payload) }
+    now = 60_000
+    val dropped = receiver.receive(sender.message(7, emptySet())!!.payload)
+    assertEquals(setOf(first, second), dropped.dropped.toSet())
+    assertTrue(dropped.added.isEmpty())
+  }
+
+  @Test
+  fun malformedFlagsAndOversizedUpdatesAreRejected() {
+    val bytes = DhtCodec.compactEndpoint(PeerEndpoint("1.2.3.4", 6881))
+    assertFailsWith<IllegalArgumentException> {
+      PeerExchange().receive(Bencode.encode(mapOf("added" to bytes, "added.f" to ByteArray(0))))
+    }
+    assertFailsWith<IllegalArgumentException> {
+      PeerExchange().receive(Bencode.encode(mapOf("added" to bytes, "dropped" to bytes)))
+    }
+  }
+
+  @Test
+  fun privateDirectory_ignoresPublicSourcesAndClearsPreviousTracker() {
+    val peers = TorrentPeerDirectory(privateTorrent = true)
+    val first = PeerEndpoint("1.2.3.4", 6881)
+    val second = PeerEndpoint("5.6.7.8", 6881)
+    assertFalse(peers.update(PeerOrigin.DHT, "dht", listOf(first)))
+    assertTrue(peers.candidates().isEmpty())
+    peers.update(PeerOrigin.TRACKER, "a", listOf(first))
+    assertFalse(peers.update(PeerOrigin.PEX, "peer", listOf(second)))
+    assertEquals(listOf(first), peers.candidates())
+    assertTrue(peers.update(PeerOrigin.TRACKER, "b", listOf(second)))
+    assertEquals(listOf(second), peers.candidates())
+  }
+
+  @Test
+  fun droppingPexProvenance_preservesOtherSources() {
+    val peers = TorrentPeerDirectory(privateTorrent = false)
+    val endpoint = PeerEndpoint("1.2.3.4", 6881)
+    peers.update(PeerOrigin.PEX, "peer", listOf(endpoint))
+    peers.update(PeerOrigin.TRACKER, "tracker", listOf(endpoint))
+    peers.update(PeerOrigin.PEX, "peer", emptyList(), listOf(endpoint))
+    assertEquals(listOf(endpoint), peers.candidates())
+  }
+
+  @Test
+  fun privateTracker_doesNotSwitchBackWhileCurrentTrackerWorks() = runTest {
+    var firstOnline = true
+    val calls = mutableListOf<String>()
+    val tiers = TrackerTiers(listOf(listOf("a"), listOf("b"))) { url, _, _ ->
+      calls += url
+      if (url == "a" && !firstOnline) error("offline")
+      TrackerResponse(emptyList(), 1)
+    }
+    tiers.preferCurrentTracker()
+    val request = TrackerAnnounce(InfoHash.fromBytes(ByteArray(20)), ByteArray(20), 6881, 0, 1)
+    tiers.announce(request)
+    firstOnline = false
+    tiers.announce(request)
+    firstOnline = true
+    tiers.announce(request)
+    assertEquals(listOf("a", "a", "b", "b"), calls)
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPexTransferTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPexTransferTest.kt
@@ -1,5 +1,6 @@
 package com.linroid.ketch.torrent
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
@@ -18,7 +19,9 @@ class TorrentPexTransferTest {
   fun pexDiscoveredPeer_completesMissingPayload() = runTest { transfer(false) }
 
   @Test
-  fun lastIntroducerCanExitImmediatelyAfterAdvertisingPayloadPeer() = runTest { transfer(true) }
+  fun lastIntroducerCanExitImmediatelyAfterAdvertisingPayloadPeer() = runTest {
+    repeat(20) { transfer(true) }
+  }
 
   private suspend fun transfer(disconnect: Boolean) {
     withContext(Dispatchers.Default) {
@@ -36,6 +39,7 @@ class TorrentPexTransferTest {
           val first = network.listen(PeerEndpoint("127.0.0.1", 0))
           val second = network.listen(PeerEndpoint("127.0.0.1", 0))
           val budget = TorrentBufferBudget(2 * 1024 * 1024)
+          val introducerClosed = CompletableDeferred<Unit>()
           val servers = listOf(first, second).mapIndexed { index, listener ->
             launch {
               val connection = listener.accept()
@@ -52,13 +56,15 @@ class TorrentPexTransferTest {
                   if (disconnect) {
                     // A repeated bitfield ends this peer without retrying the introducer.
                     wire.send(PeerMessage.Bitfield(byteArrayOf(0)))
-                    return@launch
+                    // Keep draining until the client rejects the bitfield and closes. Closing
+                    // with unread client data can send a TCP reset and discard the queued PEX.
                   }
                 }
                 while (true) {
                   val message = wire.read()
                   if (message is PeerMessage.Request) {
                     assertEquals(1, index)
+                    if (disconnect) introducerClosed.await()
                     wire.send(PeerMessage.Piece(0, 0, bytes))
                   }
                 }
@@ -66,6 +72,7 @@ class TorrentPexTransferTest {
                 // Session completion closes these peers.
               } finally {
                 connection.close()
+                if (index == 0) introducerClosed.complete(Unit)
               }
             }
           }

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPexTransferTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPexTransferTest.kt
@@ -1,0 +1,78 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class TorrentPexTransferTest {
+  @Test
+  fun pexDiscoveredPeer_completesMissingPayload() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(15_000) {
+        coroutineScope {
+          val bytes = byteArrayOf(1, 2, 3, 4)
+          val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+            "name" to "data", "length" to 4L, "piece length" to 4L,
+            "pieces" to sha1Digest(bytes)
+          ))))
+          val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+            "ketch-pex-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+          val store = TorrentPieceStore(metadata, root / "data", emptySet(), "test")
+          val network = createTorrentNetwork()
+          val first = network.listen(PeerEndpoint("127.0.0.1", 0))
+          val second = network.listen(PeerEndpoint("127.0.0.1", 0))
+          val budget = TorrentBufferBudget(2 * 1024 * 1024)
+          val servers = listOf(first, second).mapIndexed { index, listener ->
+            launch {
+              val connection = listener.accept()
+              try {
+                val wire = PeerWire(connection, metadata)
+                wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), true, false))
+                wire.send(PeerMessage.Extended(0, Bencode.encode(mapOf("m" to mapOf("ut_pex" to 7L)))))
+                wire.send(PeerMessage.Bitfield(byteArrayOf(if (index == 0) 0 else 128.toByte())))
+                wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+                if (index == 0) {
+                  wire.send(PeerMessage.Extended(2, Bencode.encode(mapOf(
+                    "added" to DhtCodec.compactEndpoint(second.local)
+                  ))))
+                }
+                while (true) {
+                  val message = wire.read()
+                  if (message is PeerMessage.Request) {
+                    assertEquals(1, index)
+                    wire.send(PeerMessage.Piece(0, 0, bytes))
+                  }
+                }
+              } catch (_: okio.IOException) {
+                // Session completion closes these peers.
+              } finally {
+                connection.close()
+              }
+            }
+          }
+          val peers = Channel<PeerEndpoint>(1)
+          peers.send(first.local)
+          peers.close()
+          try {
+            TorrentSwarm(store, network, budget, allowLocalDiscovery = true).run(peers)
+            assertContentEquals(bytes, torrentFileSystem.read(root / "data") { readByteArray() })
+            assertEquals(0, budget.allocated)
+          } finally {
+            servers.forEach { it.cancelAndJoin() }
+            network.close()
+            torrentFileSystem.deleteRecursively(root, mustExist = false)
+          }
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPexTransferTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentPexTransferTest.kt
@@ -15,7 +15,12 @@ import kotlin.test.assertEquals
 
 class TorrentPexTransferTest {
   @Test
-  fun pexDiscoveredPeer_completesMissingPayload() = runTest {
+  fun pexDiscoveredPeer_completesMissingPayload() = runTest { transfer(false) }
+
+  @Test
+  fun lastIntroducerCanExitImmediatelyAfterAdvertisingPayloadPeer() = runTest { transfer(true) }
+
+  private suspend fun transfer(disconnect: Boolean) {
     withContext(Dispatchers.Default) {
       withTimeout(15_000) {
         coroutineScope {
@@ -44,6 +49,11 @@ class TorrentPexTransferTest {
                   wire.send(PeerMessage.Extended(2, Bencode.encode(mapOf(
                     "added" to DhtCodec.compactEndpoint(second.local)
                   ))))
+                  if (disconnect) {
+                    // A repeated bitfield ends this peer without retrying the introducer.
+                    wire.send(PeerMessage.Bitfield(byteArrayOf(0)))
+                    return@launch
+                  }
                 }
                 while (true) {
                   val message = wire.read()

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/TorrentDns.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/TorrentDns.ios.kt
@@ -1,0 +1,58 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.readBytes
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import platform.posix.AF_INET
+import platform.posix.AF_INET6
+import platform.posix.AF_UNSPEC
+import platform.posix.SOCK_DGRAM
+import platform.posix.addrinfo
+import platform.posix.freeaddrinfo
+import platform.posix.getaddrinfo
+import platform.posix.sockaddr_in
+import platform.posix.sockaddr_in6
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual suspend fun resolveTorrentHost(host: String): List<ByteArray> =
+  withContext(Dispatchers.IO) {
+    require(host.isNotEmpty() && host.length <= 253)
+    memScoped {
+      val hints = alloc<addrinfo>()
+      hints.ai_family = AF_UNSPEC
+      hints.ai_socktype = SOCK_DGRAM
+      val result = alloc<CPointerVar<addrinfo>>()
+      check(getaddrinfo(host, null, hints.ptr, result.ptr) == 0) { "Torrent DNS lookup failed" }
+      val first = checkNotNull(result.value)
+      try {
+        val addresses = mutableListOf<ByteArray>()
+        var current = result.value
+        while (current != null && addresses.size < 16) {
+          val item = current.pointed
+          val address = item.ai_addr
+          if (address != null) {
+            when (item.ai_family) {
+              AF_INET -> addresses += address.reinterpret<sockaddr_in>().pointed.sin_addr.ptr
+                .reinterpret<ByteVar>().readBytes(4)
+              AF_INET6 -> addresses += address.reinterpret<sockaddr_in6>().pointed.sin6_addr.ptr
+                .reinterpret<ByteVar>().readBytes(16)
+            }
+          }
+          current = item.ai_next
+        }
+        addresses
+      } finally {
+        freeaddrinfo(first)
+      }
+    }
+  }

--- a/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/TorrentDns.jvmAndAndroid.kt
+++ b/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/TorrentDns.jvmAndAndroid.kt
@@ -1,0 +1,11 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetAddress
+
+internal actual suspend fun resolveTorrentHost(host: String): List<ByteArray> =
+  withContext(Dispatchers.IO) {
+    require(host.isNotEmpty() && host.length <= 253)
+    InetAddress.getAllByName(host).take(16).map { it.address }
+  }

--- a/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
+++ b/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/IndependentSeederTest.kt
@@ -43,6 +43,7 @@ class IndependentSeederTest {
         }
         val manager = SessionManager()
         val network = createTorrentNetwork()
+        val dhtNodes = mutableListOf<DhtNode>()
         try {
           manager.start(SessionParams(settings))
           val info = TorrentInfo(data)
@@ -53,14 +54,24 @@ class IndependentSeederTest {
           }
           val output = root.resolve("download/fixture.bin")
           val expected = TorrentMetadata.fromBencode(data)
-          val metadata = TorrentMetadataExchange(network).fetch(expected.infoHash,
-            PeerEndpoint("127.0.0.1", manager.swig().listen_port()))
+          suspend fun dhtNode(): DhtNode = DhtNode(
+            network.bindUdp(PeerEndpoint("127.0.0.1", 0)), this,
+            allowLocalAddresses = true,
+          ).also { it.start(); dhtNodes += it }
+          val router = dhtNode()
+          val announcing = dhtNode()
+          val seeking = dhtNode()
+          announcing.bootstrap(listOf(router.local))
+          announcing.peers(expected.infoHash, announcePort = manager.swig().listen_port())
+          seeking.bootstrap(listOf(router.local))
+          val endpoint = seeking.peers(expected.infoHash).single()
+          val metadata = TorrentMetadataExchange(network).fetch(expected.infoHash, endpoint)
           assertContentEquals(expected.infoBytes, metadata.infoBytes)
           val store = TorrentPieceStore(metadata, output.absolutePath.toPath(), emptySet(), "interop")
           var received = 0L
           val progress = mutableListOf<Long>()
           val peers = Channel<PeerEndpoint>(1)
-          peers.send(PeerEndpoint("127.0.0.1", manager.swig().listen_port()))
+          peers.send(endpoint)
           peers.close()
           TorrentSwarm(store, network, TorrentBufferBudget(4 * 1024 * 1024),
             downloadPayload = { received += it }, onProgress = { progress.add(it) }).run(peers)
@@ -69,6 +80,7 @@ class IndependentSeederTest {
           assertEquals(payload.size.toLong(), progress.last())
           assertTrue(store.completed())
         } finally {
+          dhtNodes.forEach { it.close() }
           network.close()
           manager.stop()
           root.deleteRecursively()


### PR DESCRIPTION
Connects the DHT foundation into bounded bootstrap, iterative lookup, announce, refresh and saved-contact recovery, with separate address-family nodes. Correlated responses validate public addresses and BEP 42 identities; identity changes require reports from three network prefixes. Routing diversity, lookup concurrency, peer storage and message work are bounded.

Adds PEX negotiation, receive quotas, connected-peer additions/drops, provenance limits and payload discovery. Private torrents reject public discovery and PEX, and stay on the current tracker until it fails.

Validation: all torrent tests pass on JVM, Android host and iOS simulator. Fixtures cover IPv4/IPv6 multi-hop lookup and warm recovery, external identity quorum, PEX-based payload completion, provenance and private tracker behavior. The JVM independent-seeder flow now discovers its endpoint through a controlled DHT, fetches metadata and verifies the downloaded payload. Runtime startup/bootstrap configuration and persistent snapshot files are assembled in the remaining integration layers.

Layer 11 of the approved stack, based on #157.
