### PR TITLE
feat(torrent): durable checkpoints and isolated pause/resume

### DIFF
--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -15,8 +15,9 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 08 Swarm and upload | https://github.com/linroid/Ketch/pull/155 | Rarity/pipelines, complementary peers, recovery, upload policies and seeding lifecycle on JVM/Android/iOS |
 | 09 Magnet metadata | https://github.com/linroid/Ketch/pull/156 | Independent seeder metadata-to-payload transfer; common negotiation, hash/size/private validation and shared cache tests |
 | 10 DHT foundations | https://github.com/linroid/Ketch/pull/157 | Published BEP 42/CRC vectors, routing/token expiry, packet quotas and IPv4/IPv6 RPC correlation |
-| 11 Trackerless discovery and PEX | Pending PR | IPv4/IPv6 multi-hop/warm DHT, PEX payload discovery, public identity quorum, private-source policy; independent DHT-to-metadata-to-payload JVM transfer |
-| 12–14 | Pending | Not implemented yet |
+| 11 Trackerless discovery and PEX | https://github.com/linroid/Ketch/pull/158 | IPv4/IPv6 multi-hop/warm DHT, PEX payload discovery, public identity quorum, private-source policy; independent DHT-to-metadata-to-payload JVM transfer |
+| 12 Durable resume | Pending PR | Journal/checkpoint/identity recovery, concurrent session pause/resume and live limits pass on JVM/Android/iOS; JVM process-crash fixtures pass at write/checkpoint boundaries |
+| 13–14 | Pending | Not implemented yet |
 
 No PR has been merged. The default transfer engine is still libtorrent4j.
 
@@ -33,3 +34,12 @@ Implementation notes:
   ownership recovery and crash-safe resume remain layer 12 work.
 - Common tests use hand-written fakes. Protocol interoperability with an independent seeder
   starts at layer 06; production source/runtime integration remains gated until layer 13.
+
+- Ownership records include OS file identity and are appended independently of TaskStore snapshots.
+  Cleanup preserves paths whose identity cannot be proven. A process exit in the tiny interval
+  between creating a file/directory and recording its identity can leave an unclaimed path;
+  recovery preserves it conservatively. Unknown temporary metadata files are also preserved.
+  Stronger descriptor-rooted protection against concurrent symlink replacement remains a final
+  storage hardening audit; current checks reject static symlink paths.
+- Native/iOS socket disconnects now use IOException consistently, and shared parent-directory
+  creation tolerates another torrent creating the same directory without claiming its ownership.

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/Bencode.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/Bencode.kt
@@ -46,9 +46,10 @@ internal object Bencode {
     return Parser(data, maxNodes).read(0)
   }
 
-  fun encode(value: Any): ByteArray {
+  fun encode(value: Any, maxBytes: Int = 4 * 1024 * 1024): ByteArray {
+    require(maxBytes > 0)
     val buffer = Buffer()
-    write(value, buffer, 0)
+    write(value, buffer, 0, maxBytes)
     return buffer.readByteArray()
   }
 
@@ -126,22 +127,22 @@ internal object Bencode {
     }
   }
 
-  private fun write(value: Any, out: Buffer, depth: Int) {
-    require(depth < 64 && out.size <= 4 * 1024 * 1024) { "Bencode exceeds limits" }
+  private fun write(value: Any, out: Buffer, depth: Int, maxBytes: Int) {
+    require(depth < 64 && out.size <= maxBytes) { "Bencode exceeds limits" }
     when (value) {
-      is Node -> write(value.value, out, depth)
-      is Int -> write(value.toLong(), out, depth)
+      is Node -> write(value.value, out, depth, maxBytes)
+      is Int -> write(value.toLong(), out, depth, maxBytes)
       is Long -> out.writeUtf8("i${value}e")
-      is String -> write(value.encodeToByteArray(), out, depth)
-      is ByteString -> write(value.toByteArray(), out, depth)
+      is String -> write(value.encodeToByteArray(), out, depth, maxBytes)
+      is ByteString -> write(value.toByteArray(), out, depth, maxBytes)
       is ByteArray -> {
-        require(value.size <= 4 * 1024 * 1024) { "Bencode string exceeds limit" }
+        require(value.size <= maxBytes) { "Bencode string exceeds limit" }
         out.writeUtf8("${value.size}:")
         out.write(value)
       }
       is List<*> -> {
         out.writeByte('l'.code)
-        value.forEach { write(requireNotNull(it) { "Null bencode value" }, out, depth + 1) }
+        value.forEach { write(requireNotNull(it) { "Null bencode value" }, out, depth + 1, maxBytes) }
         out.writeByte('e'.code)
       }
       is Map<*, *> -> {
@@ -159,13 +160,13 @@ internal object Bencode {
         }
         out.writeByte('d'.code)
         entries.forEach { (key, item) ->
-          write(key, out, depth + 1)
-          write(item, out, depth + 1)
+          write(key, out, depth + 1, maxBytes)
+          write(item, out, depth + 1, maxBytes)
         }
         out.writeByte('e'.code)
       }
       else -> throw IllegalArgumentException("Unsupported bencode value")
     }
-    require(out.size <= 4 * 1024 * 1024) { "Bencode exceeds size limit" }
+    require(out.size <= maxBytes) { "Bencode exceeds size limit" }
   }
 }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/Bencode.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/Bencode.kt
@@ -29,16 +29,21 @@ internal object Bencode {
 
   fun decode(data: ByteArray): Any = parse(data).legacyValue()
 
-  fun parse(data: ByteArray, maxBytes: Int = 4 * 1024 * 1024): Node {
-    val node = parsePrefix(data, maxBytes)
+  fun parse(data: ByteArray, maxBytes: Int = 4 * 1024 * 1024, maxNodes: Int = 100_000): Node {
+    val node = parsePrefix(data, maxBytes, maxNodes)
     require(node.end == data.size) { "Trailing bencode data" }
     return node
   }
 
   /** Parses a header followed by binary payload (BEP 9). */
-  fun parsePrefix(data: ByteArray, maxBytes: Int = 4 * 1024 * 1024): Node {
+  fun parsePrefix(
+    data: ByteArray,
+    maxBytes: Int = 4 * 1024 * 1024,
+    maxNodes: Int = 100_000,
+  ): Node {
     require(data.size <= maxBytes) { "Bencode exceeds size limit" }
-    return Parser(data).read(0)
+    require(maxNodes in 1..1_000_000)
+    return Parser(data, maxNodes).read(0)
   }
 
   fun encode(value: Any): ByteArray {
@@ -47,12 +52,12 @@ internal object Bencode {
     return buffer.readByteArray()
   }
 
-  private class Parser(private val data: ByteArray) {
+  private class Parser(private val data: ByteArray, private val maxNodes: Int) {
     private var cursor = 0
     private var nodes = 0
 
     fun read(depth: Int): Node {
-      require(depth < 64 && ++nodes <= 100_000) { "Bencode structure exceeds limits" }
+      require(depth < 64 && ++nodes <= maxNodes) { "Bencode structure exceeds limits" }
       require(cursor < data.size) { "Unexpected end of bencode" }
       val start = cursor
       val value: Any = when (data[cursor].toInt().toChar()) {

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/KotlinTorrentSession.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/KotlinTorrentSession.kt
@@ -1,0 +1,188 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.coroutines.cancellation.CancellationException
+
+/** One task owns this session, its lifecycle job, output, and checkpoint. Network/runtime are borrowed. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class KotlinTorrentSession(
+  private val store: TorrentPieceStore,
+  private val network: TorrentNetwork,
+  private val budget: TorrentBufferBudget,
+  parent: CoroutineScope,
+  connections: Int = 20,
+  private val uploadPolicy: TorrentUploadPolicy = TorrentUploadPolicy.DISABLED,
+  private val checkpoint: TorrentCheckpoint? = null,
+  private val discover: suspend (SendChannel<PeerEndpoint>, KotlinTorrentSession) -> Unit,
+  private val downloadThrottle: suspend (Int) -> Unit = {},
+  private val uploadThrottle: suspend (Int) -> Unit = {},
+) : TorrentSession {
+  init { require(connections in 1..512) }
+
+  private val scope = CoroutineScope(parent.coroutineContext +
+    SupervisorJob(parent.coroutineContext[Job]) + Dispatchers.Default)
+  private val lifecycle = Mutex()
+  private val rate = TorrentRateLimiter()
+  private val connectionLimit = AtomicInt(connections)
+  private val received = AtomicLong(checkpoint?.receivedBytes ?: 0)
+  private val uploaded = AtomicLong(checkpoint?.uploadedBytes ?: 0)
+  private val clock = monotonicClock()
+  private val speedMutex = Mutex()
+  private var sampleTime = clock()
+  private var sampleBytes = 0L
+  private val currentSpeed = AtomicLong(0)
+  private val lastPayload = AtomicLong(0)
+  private var job: Job? = null
+  private var closed = false
+  private var recovered = false
+  private val _state = MutableStateFlow(TorrentSessionState.PAUSED)
+  private val _downloadedBytes = MutableStateFlow(0L)
+  private val _failure = MutableStateFlow<Throwable?>(null)
+
+  override val infoHash: String get() = store.metadata.infoHash.hex
+  override val totalBytes: Long get() = store.totalSelectedBytes
+  override val downloadedBytes: StateFlow<Long> get() = _downloadedBytes
+  override val state: StateFlow<TorrentSessionState> get() = _state
+  val failure: StateFlow<Throwable?> get() = _failure
+  val receivedBytes: Long get() = received.load()
+  val uploadedBytes: Long get() = uploaded.load()
+  override val downloadSpeed: Long get() = if (clock() - lastPayload.load() > 2000) 0
+    else currentSpeed.load()
+
+  suspend fun verifiedPieces(): BooleanArray = store.verifiedPieces()
+  suspend fun fileProgress(): LongArray = store.progress()
+
+  override suspend fun resume() = lifecycle.withLock {
+    check(!closed) { "Torrent session is closed" }
+    scope.coroutineContext.ensureActive()
+    if (job?.isActive == true) return@withLock
+    _failure.value = null
+    job = scope.launch {
+      try {
+        _state.value = TorrentSessionState.CHECKING_FILES
+        if (!recovered) {
+          checkpoint?.let { store.restore(it) }
+          recovered = true
+        }
+        store.initialize()
+        store.recheck()
+        _downloadedBytes.value = store.progress().sum()
+        if (store.completed() && uploadPolicy != TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
+          store.finish()
+          store.persistCheckpoint(received.load(), uploaded.load())
+          _state.value = TorrentSessionState.FINISHED
+          return@launch
+        }
+        speedMutex.withLock {
+          sampleTime = clock()
+          sampleBytes = received.load()
+          currentSpeed.store(0)
+        }
+        _state.value = TorrentSessionState.DOWNLOADING
+        coroutineScope {
+          val peers = Channel<PeerEndpoint>(256)
+          val discovery = launch {
+            try { discover(peers, this@KotlinTorrentSession) } finally { peers.close() }
+          }
+          try {
+            TorrentSwarm(store, network, budget,
+              connections = { connectionLimit.load() }, uploadPolicy = uploadPolicy,
+              downloadPayload = { bytes ->
+                val total = received.fetchAndAdd(bytes.toLong()) + bytes
+                val now = clock()
+                lastPayload.store(now)
+                speedMutex.withLock {
+                  if (now - sampleTime >= 1000) {
+                    currentSpeed.store(((total - sampleBytes) * 1000.0 / (now - sampleTime)).toLong())
+                    sampleTime = now
+                    sampleBytes = total
+                  }
+                }
+                rate.acquire(bytes)
+                downloadThrottle(bytes)
+              },
+              uploadPayload = { bytes ->
+                uploadThrottle(bytes)
+                uploaded.fetchAndAdd(bytes.toLong())
+              },
+              onProgress = { _downloadedBytes.value = it },
+              onCompleted = {
+                store.persistCheckpoint(received.load(), uploaded.load())
+                _state.value = if (uploadPolicy == TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
+                  TorrentSessionState.SEEDING
+                } else TorrentSessionState.FINISHED
+              },
+            ).run(peers)
+          } finally {
+            withContext(NonCancellable) { discovery.cancelAndJoin(); peers.cancel() }
+          }
+        }
+      } catch (e: CancellationException) {
+        throw e
+      } catch (e: Exception) {
+        _failure.value = e
+        _state.value = TorrentSessionState.STOPPED
+      }
+    }
+  }
+
+  override suspend fun pause() = lifecycle.withLock {
+    if (closed) return@withLock
+    job?.cancelAndJoin()
+    job = null
+    _state.value = TorrentSessionState.PAUSED
+    currentSpeed.store(0)
+    if (store.isInitialized()) store.persistCheckpoint(received.load(), uploaded.load())
+  }
+
+  override suspend fun saveResumeData(): ByteArray? = if (store.isInitialized()) {
+    store.persistCheckpoint(received.load(), uploaded.load())
+  } else null
+
+  override fun setDownloadRateLimit(bytesPerSecond: Long) = rate.set(bytesPerSecond)
+
+  fun setConnections(value: Int) {
+    require(value in 1..512)
+    connectionLimit.store(value)
+  }
+
+  override fun setFilePriorities(priorities: Map<Int, Int>) {
+    require(priorities.values.all { it in 0..7 })
+    require(priorities.filterValues { it > 0 }.keys == store.selectedIndices) {
+      "Change file selection by creating a new task"
+    }
+  }
+
+  suspend fun close(deleteFiles: Boolean = false) = lifecycle.withLock {
+    if (closed) return@withLock
+    closed = true
+    job?.cancelAndJoin()
+    job = null
+    scope.cancel()
+    _state.value = TorrentSessionState.STOPPED
+    if (deleteFiles) {
+      if (!recovered) checkpoint?.let { store.restore(it) }
+      store.recoverOwnership()
+      store.cleanup()
+    }
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentCheckpoint.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentCheckpoint.kt
@@ -25,7 +25,7 @@ internal data class TorrentCheckpoint(
     "verified" to pieceBitfield(verified),
     "files" to files.map { mapOf("path" to it.path, "identity" to it.identity) },
     "directories" to directories.map { mapOf("path" to it.path, "identity" to it.identity) }
-  )).let { MAGIC + it }.also { require(it.size <= MAX_BYTES) }
+  ), maxBytes = MAX_BYTES - MAGIC.size).let { MAGIC + it }.also { require(it.size <= MAX_BYTES) }
 
   companion object {
     const val MAX_BYTES = 16 * 1024 * 1024

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentCheckpoint.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentCheckpoint.kt
@@ -1,0 +1,83 @@
+package com.linroid.ketch.torrent
+
+import okio.Path
+import okio.Path.Companion.toPath
+
+internal data class TorrentOwnedPath(val path: String, val identity: String)
+
+/** Versioned Kotlin state. The bitmap is a hint; recovery always rehashes the actual output. */
+internal data class TorrentCheckpoint(
+  val taskId: String,
+  val metadata: TorrentMetadata,
+  val output: String,
+  val selected: Set<Int>,
+  val verified: BooleanArray,
+  val files: List<TorrentOwnedPath>,
+  val directories: List<TorrentOwnedPath>,
+  val receivedBytes: Long = 0,
+  val uploadedBytes: Long = 0,
+) {
+  fun encode(): ByteArray = Bencode.encode(mapOf(
+    "received" to receivedBytes, "uploaded" to uploadedBytes,
+    "kind" to KIND, "version" to 1L, "task" to taskId,
+    "metainfo" to metadata.metainfoBytes, "hash" to metadata.infoHash.toBytes(),
+    "output" to output, "selected" to selected.sorted().map { it.toLong() },
+    "verified" to pieceBitfield(verified),
+    "files" to files.map { mapOf("path" to it.path, "identity" to it.identity) },
+    "directories" to directories.map { mapOf("path" to it.path, "identity" to it.identity) }
+  )).let { MAGIC + it }.also { require(it.size <= MAX_BYTES) }
+
+  companion object {
+    const val MAX_BYTES = 16 * 1024 * 1024
+    private val MAGIC = "KETCH-TORRENT\n".encodeToByteArray()
+    private const val KIND = "ketch-kotlin-torrent"
+
+    /** Returns null for legacy native blobs. Malformed recognized Kotlin state is an error. */
+    fun decode(bytes: ByteArray): TorrentCheckpoint? {
+      if (bytes.size < MAGIC.size || !bytes.copyOfRange(0, MAGIC.size).contentEquals(MAGIC)) {
+        return null
+      }
+      require(bytes.size <= MAX_BYTES)
+      val root = Bencode.parse(bytes.copyOfRange(MAGIC.size, bytes.size), MAX_BYTES, 1_000_000)
+      require(root["kind"]?.text() == KIND)
+      require(root["version"]?.integer == 1L) { "Unsupported torrent checkpoint version" }
+      val metadata = TorrentMetadata.fromBencode(requireNotNull(root["metainfo"]?.bytes))
+      require(root["hash"]?.bytes?.contentEquals(metadata.infoHash.toBytes()) == true)
+      val task = requireNotNull(root["task"]?.text())
+      require(task.isNotEmpty() && task.length <= 128 && task.all { it.isLetterOrDigit() || it == '-' })
+      val output = requireNotNull(root["output"]?.text())
+      require(output.length <= 8192 && output.toPath().isAbsolute)
+      val selection = requireNotNull(root["selected"]?.list)
+      require(selection.size <= metadata.files.size)
+      val selected = selection.map { item ->
+        val index = requireNotNull(item.integer)
+        require(index in 0 until metadata.files.size.toLong())
+        index.toInt()
+      }.toSet()
+      require(selected.size == selection.size)
+      val count = metadata.pieceHashes.size / 20
+      val bits = requireNotNull(root["verified"]?.bytes)
+      require(bits.size == (count + 7) / 8)
+      if (count % 8 != 0) require(bits.last().toInt() and ((1 shl (8 - count % 8)) - 1) == 0)
+      val verified = BooleanArray(count) { bits[it / 8].toInt() and (128 ushr (it % 8)) != 0 }
+      fun owned(key: String): List<TorrentOwnedPath> {
+        val list = requireNotNull(root[key]?.list)
+        require(list.size <= 250_000)
+        return list.map {
+          val path = requireNotNull(it["path"]?.text())
+          val identity = requireNotNull(it["identity"]?.text())
+          require(path.length <= 8192 && path.toPath().isAbsolute && identity.length in 1..512)
+          TorrentOwnedPath(path, identity)
+        }.also { paths -> require(paths.map { it.path }.distinct().size == paths.size) }
+      }
+      val receivedBytes = root["received"]?.integer ?: 0L
+      val uploadedBytes = root["uploaded"]?.integer ?: 0L
+      require(receivedBytes >= 0 && uploadedBytes >= 0)
+      return TorrentCheckpoint(task, metadata, output, selected, verified,
+        owned("files"), owned("directories"), receivedBytes, uploadedBytes)
+    }
+  }
+}
+
+/** Stable OS file identity, read without following a symlink. Null means ownership is unprovable. */
+internal expect fun torrentFileIdentity(path: Path): String?

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentOwnershipJournal.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentOwnershipJournal.kt
@@ -1,0 +1,127 @@
+package com.linroid.ketch.torrent
+
+import okio.Buffer
+import okio.FileSystem
+import okio.Path
+import okio.use
+
+/** Append-only ownership records survive a process exit before TaskStore publishes a checkpoint. */
+internal class TorrentOwnershipJournal(
+  private val path: Path,
+  private val binding: ByteArray,
+  private val fileSystem: FileSystem,
+) {
+  private var position = 0L
+  private var compactedAt = 0L
+  val needsCompaction: Boolean get() = position - compactedAt >= 1024 * 1024 ||
+    position >= MAX_BYTES - 1024 * 1024
+
+  fun load(): List<Pair<Boolean, TorrentOwnedPath>> {
+    position = 0
+    if (!fileSystem.exists(path)) return emptyList()
+    require(fileSystem.metadata(path).isRegularFile && fileSystem.metadata(path).symlinkTarget == null)
+    val size = fileSystem.metadata(path).size ?: 0
+    require(size <= MAX_BYTES)
+    val bytes = fileSystem.read(path) { readByteArray() }
+    val input = Buffer().write(bytes)
+    val records = mutableListOf<Pair<Boolean, TorrentOwnedPath>>()
+    var first = true
+    while (input.size >= 4) {
+      val length = input.readInt()
+      require(length in 1..16_384)
+      if (input.size < length) break // Discard a torn final append; never infer ownership from it.
+      val value = input.readByteArray(length.toLong())
+      if (first) {
+        require(value.contentEquals(binding)) { "Ownership journal belongs to another task" }
+        first = false
+      } else {
+        val node = Bencode.parse(value, 16_384)
+        val directory = node["directory"]?.integer
+        require(directory == 0L || directory == 1L)
+        val name = requireNotNull(node["path"]?.text())
+        val identity = requireNotNull(node["identity"]?.text())
+        require(name.length <= 8192 && identity.length in 1..512)
+        records += (directory == 1L) to TorrentOwnedPath(name, identity)
+        require(records.size <= 250_000)
+      }
+      position += length + 4
+    }
+    require(!first) { "Ownership journal header is incomplete" }
+    if (position < size) fileSystem.openReadWrite(path, mustExist = true).use {
+      it.resize(position)
+      it.flush()
+    }
+    return records
+  }
+
+  fun initialize() {
+    if (position != 0L) return
+    require(!fileSystem.exists(path)) { "Ownership journal was not loaded" }
+    val temp = checkNotNull(path.parent) /
+      ("ownership-init-" + InfoHash.fromBytes(torrentRandomBytes(20)).hex + ".tmp")
+    var created = false
+    try {
+      fileSystem.openReadWrite(temp, mustCreate = true).use { handle ->
+        created = true
+        val bytes = Buffer().writeInt(binding.size).write(binding).readByteArray()
+        handle.write(0, bytes, 0, bytes.size)
+        handle.flush()
+        position = bytes.size.toLong()
+      }
+      fileSystem.atomicMove(temp, path)
+    } finally {
+      if (created) fileSystem.delete(temp, mustExist = false)
+    }
+  }
+
+  fun append(directory: Boolean, owned: TorrentOwnedPath) {
+    val data = Bencode.encode(mapOf("directory" to if (directory) 1L else 0L,
+      "path" to owned.path, "identity" to owned.identity))
+    require(data.size <= 16_384 && data.size + 4 <= MAX_BYTES - position)
+    val bytes = Buffer().writeInt(data.size).write(data).readByteArray()
+    fileSystem.openReadWrite(path, mustExist = true).use { handle ->
+      handle.write(position, bytes, 0, bytes.size)
+      handle.flush()
+      position += bytes.size
+    }
+  }
+
+  /** Atomically replaces stale creation records with the current ownership set. */
+  fun compact(records: List<Pair<Boolean, TorrentOwnedPath>>): String {
+    val temp = checkNotNull(path.parent) /
+      ("ownership-init-" + InfoHash.fromBytes(torrentRandomBytes(20)).hex + ".tmp")
+    var created = false
+    var written = 0L
+    var identity: String? = null
+    try {
+      fileSystem.openReadWrite(temp, mustCreate = true).use { handle ->
+        created = true
+        identity = requireNotNull(torrentFileIdentity(temp))
+        fun frame(bytes: ByteArray) {
+          require(bytes.size <= 16_384 && written + bytes.size + 4 <= MAX_BYTES)
+          val framed = Buffer().writeInt(bytes.size).write(bytes).readByteArray()
+          handle.write(written, framed, 0, framed.size)
+          written += framed.size
+        }
+        frame(binding)
+        val current = records.filter { it.second.path != path.toString() } +
+          (false to TorrentOwnedPath(path.toString(), identity!!))
+        for ((directory, owned) in current) {
+          frame(Bencode.encode(mapOf("directory" to if (directory) 1L else 0L,
+            "path" to owned.path, "identity" to owned.identity)))
+        }
+        handle.flush()
+      }
+      fileSystem.atomicMove(temp, path)
+      position = written
+      compactedAt = position
+      return checkNotNull(identity)
+    } finally {
+      if (created) fileSystem.delete(temp, mustExist = false)
+    }
+  }
+
+  companion object {
+    private const val MAX_BYTES = 32L * 1024 * 1024
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPieceStore.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPieceStore.kt
@@ -32,6 +32,15 @@ internal class TorrentPieceStore(
   private val ownedFiles = linkedMapOf<Path, String>()
   private val ownedDirectories = linkedMapOf<Path, String>()
   private val sidecar: Path
+  private val allowedOutputFiles by lazy { this.selected.map(::filePath).toSet() }
+  private val allowedDirectories by lazy {
+    buildSet {
+      for (file in allowedOutputFiles + journalPath) {
+        var parent = file.parent
+        while (parent != null && parent != parent.root && add(parent)) parent = parent.parent
+      }
+    }
+  }
   private var initialized = false
   private var journalReady = false
   private var ownershipLoaded = false
@@ -299,14 +308,10 @@ internal class TorrentPieceStore(
   private fun restoreOwned(directory: Boolean, owned: TorrentOwnedPath) {
     val path = owned.path.toPath()
     require(path.isAbsolute && path == path.toString().toPath(normalize = true))
-    val outputFiles = selected.map(::filePath)
     val allowed = if (directory) {
-      // Include only directories on an output/sidecar ancestry, never the filesystem root.
-      path != path.root && (outputFiles + journalPath).any { candidate ->
-        generateSequence(candidate.parent) { it.parent }.any { it == path }
-      }
+      path in allowedDirectories
     } else {
-      path in outputFiles || path.parent == sidecar && (
+      path in allowedOutputFiles || path.parent == sidecar && (
         path.name == "ownership" || path.name == "checkpoint" ||
           Regex("checkpoint-[0-9a-f]{40}\\.tmp").matches(path.name) ||
           path.name.removeSuffix(".piece").toIntOrNull()?.let {

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPieceStore.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentPieceStore.kt
@@ -18,7 +18,7 @@ internal class TorrentPieceStore(
   val metadata: TorrentMetadata,
   output: Path,
   selected: Set<Int>,
-  taskId: String,
+  private val taskId: String,
   private val fileSystem: FileSystem = torrentFileSystem,
 ) {
   private val mutex = Mutex()
@@ -29,10 +29,21 @@ internal class TorrentPieceStore(
   private val wanted = BooleanArray(verified.size)
   private val fileProgress = LongArray(metadata.files.size)
   private var remaining = 0
-  private val ownedFiles = linkedSetOf<Path>()
-  private val ownedDirectories = linkedSetOf<Path>()
+  private val ownedFiles = linkedMapOf<Path, String>()
+  private val ownedDirectories = linkedMapOf<Path, String>()
   private val sidecar: Path
   private var initialized = false
+  private var journalReady = false
+  private var ownershipLoaded = false
+  private val pendingOwnership = mutableListOf<Pair<Boolean, TorrentOwnedPath>>()
+  private val journalPath: Path get() = sidecar / "ownership"
+  private val journal by lazy {
+    TorrentOwnershipJournal(journalPath, Bencode.encode(mapOf(
+      "hash" to metadata.infoHash.toBytes(), "task" to taskId, "output" to output.toString()
+    )), fileSystem)
+  }
+  val outputPath: String get() = output.toString()
+  val selectedIndices: Set<Int> get() = selected.toSet()
 
   val pieceCount: Int get() = verified.size
   val totalSelectedBytes: Long get() = selected.sumOf { metadata.files[it].size }
@@ -72,6 +83,20 @@ internal class TorrentPieceStore(
   suspend fun initialize() = mutex.withLock {
     withContext(Dispatchers.IO) {
       if (initialized) return@withContext
+      ensureDirectory(sidecar)
+      loadOwnership()
+      journal.initialize()
+      journalReady = true
+      for (path in ownedFiles.keys.toList()) {
+        if (path.parent == sidecar && Regex("checkpoint-[0-9a-f]{40}\\.tmp").matches(path.name) &&
+          torrentFileIdentity(path) == ownedFiles[path]) {
+          fileSystem.delete(path, mustExist = false)
+          ownedFiles.remove(path)
+        }
+      }
+      for ((directory, owned) in pendingOwnership) journal.append(directory, owned)
+      pendingOwnership.clear()
+      recordOwned(journalPath, directory = false)
       if (metadata.isMultiFile) ensureDirectory(output)
       for (index in selected) {
         val path = filePath(index)
@@ -79,7 +104,7 @@ internal class TorrentPieceStore(
         validateRegularPath(path)
         if (!fileSystem.exists(path)) {
           fileSystem.openReadWrite(path, mustCreate = true).use {
-            ownedFiles.add(path)
+            recordOwned(path, directory = false)
             it.flush()
           }
         }
@@ -154,6 +179,8 @@ internal class TorrentPieceStore(
 
   suspend fun progress(): LongArray = mutex.withLock { fileProgress.copyOf() }
 
+  suspend fun isInitialized(): Boolean = mutex.withLock { initialized }
+
   suspend fun completed(): Boolean = mutex.withLock { initialized && remaining == 0 }
 
   suspend fun finish() = mutex.withLock {
@@ -174,17 +201,18 @@ internal class TorrentPieceStore(
 
   suspend fun verifiedPieces(): BooleanArray = mutex.withLock { verified.copyOf() }
 
-  /** Cleanup is deliberately limited to files this instance created. */
+  /** Deletes only recorded paths whose OS identity still matches the task-owned file. */
   suspend fun cleanup() = mutex.withLock {
     withContext(Dispatchers.IO) {
-      for (path in ownedFiles.toList().asReversed()) {
+      val files = ownedFiles.toList().asReversed().sortedBy { it.first == journalPath }
+      for ((path, identity) in files) {
         validateRegularPath(path)
-        fileSystem.delete(path, mustExist = false)
+        if (torrentFileIdentity(path) == identity) fileSystem.delete(path, mustExist = false)
       }
-      for (path in ownedDirectories.toList().asReversed()) {
+      for ((path, identity) in ownedDirectories.toList().sortedByDescending { it.first.segments.size }) {
         validateParents(path)
         val directory = fileSystem.metadataOrNull(path)?.isDirectory == true
-        if (directory && fileSystem.list(path).isEmpty()) {
+        if (directory && torrentFileIdentity(path) == identity && fileSystem.list(path).isEmpty()) {
           fileSystem.delete(path)
         }
       }
@@ -194,7 +222,102 @@ internal class TorrentPieceStore(
   }
 
   suspend fun ownedPaths(): Pair<List<String>, List<String>> = mutex.withLock {
-    ownedFiles.map { it.toString() } to ownedDirectories.map { it.toString() }
+    ownedFiles.keys.map { it.toString() } to ownedDirectories.keys.map { it.toString() }
+  }
+
+  suspend fun recoverOwnership() = mutex.withLock {
+    withContext(Dispatchers.IO) { loadOwnership() }
+  }
+
+  private fun loadOwnership() {
+    if (ownershipLoaded || !fileSystem.exists(sidecar)) return
+    validateParents(journalPath)
+    for ((directory, owned) in journal.load()) restoreOwned(directory, owned)
+    ownershipLoaded = true
+  }
+
+  suspend fun checkpoint(): TorrentCheckpoint = mutex.withLock { snapshot() }
+
+  suspend fun restore(checkpoint: TorrentCheckpoint) = mutex.withLock {
+    require(checkpoint.taskId == taskId && checkpoint.metadata.infoHash == metadata.infoHash)
+    require(checkpoint.output == output.toString() &&
+      checkpoint.selected.ifEmpty { metadata.files.indices.toSet() } == selected)
+    for (owned in checkpoint.files) restoreOwned(false, owned)
+    for (owned in checkpoint.directories) restoreOwned(true, owned)
+    // Do not trust checkpoint.verified. initialize()/recheck() prove the files before progress.
+  }
+
+  /** Flushes a snapshot file before returning bytes for publication through TaskStore. */
+  suspend fun persistCheckpoint(receivedBytes: Long = 0, uploadedBytes: Long = 0): ByteArray =
+    mutex.withLock {
+    require(receivedBytes >= 0 && uploadedBytes >= 0)
+    check(initialized)
+    withContext(Dispatchers.IO) {
+      if (journal.needsCompaction) {
+        require(torrentFileIdentity(journalPath) == ownedFiles[journalPath])
+        val records = ownedDirectories.map { true to TorrentOwnedPath(it.key.toString(), it.value) } +
+          ownedFiles.map { false to TorrentOwnedPath(it.key.toString(), it.value) }
+        ownedFiles[journalPath] = journal.compact(records)
+      }
+      val checkpointPath = sidecar / "checkpoint"
+      validateRegularPath(checkpointPath)
+      if (fileSystem.exists(checkpointPath)) {
+        require(ownedFiles[checkpointPath] == torrentFileIdentity(checkpointPath)) {
+          "Checkpoint path is not owned by this task"
+        }
+      }
+      val temp = sidecar / ("checkpoint-" + InfoHash.fromBytes(torrentRandomBytes(20)).hex + ".tmp")
+      val data = snapshot().copy(receivedBytes = receivedBytes, uploadedBytes = uploadedBytes).encode()
+      fileSystem.openReadWrite(temp, mustCreate = true).use { handle ->
+        recordOwned(temp, directory = false)
+        handle.write(0, data, 0, data.size)
+        handle.flush()
+      }
+      val identity = checkNotNull(ownedFiles[temp])
+      journal.append(false, TorrentOwnedPath(checkpointPath.toString(), identity))
+      fileSystem.atomicMove(temp, checkpointPath)
+      ownedFiles.remove(temp)
+      ownedFiles[checkpointPath] = identity
+      snapshot().copy(receivedBytes = receivedBytes, uploadedBytes = uploadedBytes).encode()
+    }
+  }
+
+  private fun snapshot(): TorrentCheckpoint = TorrentCheckpoint(taskId, metadata,
+    output.toString(), selected, verified.copyOf(),
+    ownedFiles.map { TorrentOwnedPath(it.key.toString(), it.value) },
+    ownedDirectories.map { TorrentOwnedPath(it.key.toString(), it.value) })
+
+  private fun recordOwned(path: Path, directory: Boolean) {
+    val identity = requireNotNull(torrentFileIdentity(path)) { "Filesystem has no safe file identity" }
+    val paths = if (directory) ownedDirectories else ownedFiles
+    if (paths[path] == identity) return
+    paths[path] = identity
+    val owned = TorrentOwnedPath(path.toString(), identity)
+    if (journalReady) journal.append(directory, owned) else pendingOwnership += directory to owned
+  }
+
+  private fun restoreOwned(directory: Boolean, owned: TorrentOwnedPath) {
+    val path = owned.path.toPath()
+    require(path.isAbsolute && path == path.toString().toPath(normalize = true))
+    val outputFiles = selected.map(::filePath)
+    val allowed = if (directory) {
+      // Include only directories on an output/sidecar ancestry, never the filesystem root.
+      path != path.root && (outputFiles + journalPath).any { candidate ->
+        generateSequence(candidate.parent) { it.parent }.any { it == path }
+      }
+    } else {
+      path in outputFiles || path.parent == sidecar && (
+        path.name == "ownership" || path.name == "checkpoint" ||
+          Regex("checkpoint-[0-9a-f]{40}\\.tmp").matches(path.name) ||
+          path.name.removeSuffix(".piece").toIntOrNull()?.let {
+            path.name == "$it.piece" && it in 0 until pieceCount && needed(it)
+          } == true)
+    }
+    require(allowed) { "Ownership path escapes torrent output" }
+    validateParents(path)
+    if (torrentFileIdentity(path) == owned.identity) {
+      (if (directory) ownedDirectories else ownedFiles)[path] = owned.identity
+    }
   }
 
   private fun readPiece(index: Int): ByteArray {
@@ -225,7 +348,7 @@ internal class TorrentPieceStore(
     validateRegularPath(path)
     val existed = fileSystem.exists(path)
     fileSystem.openReadWrite(path, mustCreate = !existed).use { handle ->
-      if (!existed) ownedFiles.add(path)
+      if (!existed) recordOwned(path, directory = false)
       handle.write(offset, bytes, 0, bytes.size)
       handle.flush()
     }
@@ -252,8 +375,15 @@ internal class TorrentPieceStore(
       val info = fileSystem.metadataOrNull(current)
       require(info?.symlinkTarget == null) { "Symlink destination is not supported" }
       if (info == null) {
-        fileSystem.createDirectory(current, mustCreate = true)
-        ownedDirectories.add(current)
+        val created = try {
+          fileSystem.createDirectory(current, mustCreate = true)
+          true
+        } catch (e: okio.IOException) {
+          val concurrent = fileSystem.metadataOrNull(current)
+          if (concurrent?.isDirectory != true || concurrent.symlinkTarget != null) throw e
+          false
+        }
+        if (created) recordOwned(current, directory = true)
       } else require(info.isDirectory) { "Destination parent is not a directory" }
     }
   }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentRateLimiter.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentRateLimiter.kt
@@ -1,0 +1,43 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/** Live rate changes take effect within 50 ms, including removing a limit while waiting. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class TorrentRateLimiter(
+  bytesPerSecond: Long = 0,
+  private val nowMs: () -> Long = monotonicClock(),
+) {
+  private val rate = AtomicLong(bytesPerSecond)
+  private val mutex = Mutex()
+  private var tokens = 16_384.0
+  private var updated = nowMs()
+
+  init { require(bytesPerSecond >= 0) }
+
+  fun set(bytesPerSecond: Long) {
+    require(bytesPerSecond >= 0)
+    rate.store(bytesPerSecond)
+  }
+
+  suspend fun acquire(bytes: Int) {
+    require(bytes >= 0)
+    var remaining = bytes
+    while (remaining > 0) {
+      val consumed = mutex.withLock {
+        val currentRate = rate.load()
+        if (currentRate == 0L) return
+        val now = nowMs()
+        tokens = minOf(16_384.0, tokens + (now - updated).coerceAtLeast(0) * currentRate.toDouble() / 1000.0)
+        updated = now
+        minOf(remaining, tokens.toInt()).also { tokens -= it }
+      }
+      remaining -= consumed
+      if (remaining > 0) delay(50)
+    }
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -71,12 +71,12 @@ internal class TorrentSwarm(
     var complete = false
     var nextId = 0
     fun acceptPex(source: PeerEndpoint, update: PexUpdate) {
-    pexDirectory.update(PeerOrigin.PEX, "${source.host}:${source.port}", update.added,
-      update.dropped)
-    for (endpoint in pexDirectory.candidates()) {
-      if (endpoint !in attempts && endpoint !in pending &&
-        attempts.size + pending.size < 4096) pending.addLast(endpoint)
-    }
+      pexDirectory.update(PeerOrigin.PEX, "${source.host}:${source.port}", update.added,
+        update.dropped)
+      for (endpoint in pexDirectory.candidates()) {
+        if (endpoint !in attempts && endpoint !in pending &&
+          attempts.size + pending.size < 4096) pending.addLast(endpoint)
+      }
     }
     try {
       while (currentCoroutineContext().isActive) {
@@ -188,12 +188,14 @@ internal class TorrentSwarm(
         wire.send(PeerMessage.Bitfield(pieceBitfield(advertised)))
         wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
         val messages = Channel<PeerMessage>(1)
+        val consumed = Channel<Unit>(1)
         val reader = launch {
           try {
             while (isActive) {
               val message = wire.read()
-              if (message is PeerMessage.Piece) downloadPayload(message.bytes.size)
               messages.send(message)
+              // Do not start an idle read while the actor intentionally waits on a rate limiter.
+              consumed.receive()
             }
           } catch (e: Throwable) {
             messages.close(e)
@@ -212,6 +214,11 @@ internal class TorrentSwarm(
               onTimeout(100) { null }
             }
             if (message != null) {
+              if (message is PeerMessage.Piece) {
+                val throttling = TimeSource.Monotonic.markNow()
+                downloadPayload(message.bytes.size)
+                lastBlock += throttling.elapsedNow()
+              }
               val accepted = state.received(message)
               when (message) {
                 is PeerMessage.Bitfield, is PeerMessage.Have ->
@@ -294,6 +301,7 @@ internal class TorrentSwarm(
                 else -> Unit
               }
             }
+            if (message != null) consumed.trySend(Unit)
             uploadCache.expire()
             if (state.interested && !uploadSlot && uploadPolicy != TorrentUploadPolicy.DISABLED &&
               uploadSlots.tryAcquire()) {
@@ -368,6 +376,7 @@ internal class TorrentSwarm(
               }
             }
             messages.cancel()
+            consumed.cancel()
           }
         }
       } finally {

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/KotlinTorrentSessionTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/KotlinTorrentSessionTest.kt
@@ -1,0 +1,114 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class KotlinTorrentSessionTest {
+  @Test
+  fun pauseOneOfTwoSessions_thenResumeAndRecoverCompletedCheckpointOffline() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(20_000) {
+        coroutineScope {
+          val network = createTorrentNetwork()
+          val budget = TorrentBufferBudget(4 * 1024 * 1024)
+          val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+            "ketch-sessions-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+          val payloads = listOf(byteArrayOf(1, 2, 3, 4), byteArrayOf(5, 6, 7, 8))
+          val metadata = payloads.mapIndexed { index, bytes ->
+            TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+              "name" to "file$index", "length" to 4L, "piece length" to 4L,
+              "pieces" to sha1Digest(bytes)
+            ))))
+          }
+          val gates = List(2) { CompletableDeferred<Unit>() }
+          val requested = List(2) { CompletableDeferred<Unit>() }
+          val listeners = List(2) { network.listen(PeerEndpoint("127.0.0.1", 0)) }
+          val servers = listeners.mapIndexed { index, listener -> launch {
+            while (isActive) {
+              val connection = listener.accept()
+              launch {
+                try {
+                  val wire = PeerWire(connection, metadata[index])
+                  wire.handshake(PeerHandshake(metadata[index].infoHash, torrentRandomBytes(20),
+                    false, false))
+                  wire.send(PeerMessage.Bitfield(byteArrayOf(128.toByte())))
+                  wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+                  while (true) {
+                    if (wire.read() is PeerMessage.Request) {
+                      requested[index].complete(Unit)
+                      gates[index].await()
+                      wire.send(PeerMessage.Piece(0, 0, payloads[index]))
+                    }
+                  }
+                } catch (_: okio.IOException) {
+                  // Pausing or completing closes this accepted connection.
+                } finally { connection.close() }
+              }
+            }
+          } }
+          fun store(index: Int) = TorrentPieceStore(metadata[index], root / "file$index",
+            emptySet(), "task$index")
+          val sessions = List(2) { index ->
+            KotlinTorrentSession(store(index), network, budget, this,
+              discover = { peers, _ -> peers.send(listeners[index].local) })
+          }
+          try {
+            sessions[0].pause() // Pausing before initialization must not create output or fail.
+            sessions.forEach { it.resume() }
+            while (requested.any { !it.isCompleted }) {
+              sessions.forEach { it.failure.value?.let { failure -> throw failure } }
+              delay(10)
+            }
+            sessions[0].pause()
+            assertEquals(TorrentSessionState.PAUSED, sessions[0].state.value)
+            gates[1].complete(Unit)
+            awaitComplete(sessions[1])
+            assertEquals(4L, sessions[1].downloadedBytes.value)
+            sessions[0].resume()
+            gates[0].complete(Unit)
+            awaitComplete(sessions[0])
+            val checkpoint = assertNotNull(TorrentCheckpoint.decode(
+              assertNotNull(sessions[0].saveResumeData())))
+            sessions.forEach { it.close() }
+            val restored = KotlinTorrentSession(store(0), network, budget, this,
+              checkpoint = checkpoint, discover = { _, _ -> error("Unexpected rediscovery") })
+            try {
+              restored.resume()
+              awaitComplete(restored)
+              assertContentEquals(payloads[0],
+                torrentFileSystem.read(root / "file0") { readByteArray() })
+              assertEquals(4L, restored.receivedBytes)
+            } finally { restored.close() }
+            assertEquals(0, budget.allocated)
+          } finally {
+            sessions.forEach { it.close() }
+            servers.forEach { it.cancelAndJoin() }
+            network.close()
+            torrentFileSystem.deleteRecursively(root, mustExist = false)
+          }
+        }
+      }
+    }
+  }
+  private suspend fun awaitComplete(session: KotlinTorrentSession) {
+    val state = session.state.first {
+      it == TorrentSessionState.FINISHED || it == TorrentSessionState.STOPPED
+    }
+    assertEquals(TorrentSessionState.FINISHED, state, session.failure.value?.stackTraceToString())
+  }
+
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentCheckpointTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentCheckpointTest.kt
@@ -1,0 +1,133 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import okio.FileSystem
+import okio.Path
+import okio.use
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TorrentCheckpointTest {
+  private val bytes = "0123456789".encodeToByteArray()
+  private val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+    "name" to "pack", "piece length" to 4L,
+    "pieces" to (sha1Digest(bytes.copyOfRange(0, 4)) + sha1Digest(bytes.copyOfRange(4, 8)) +
+      sha1Digest(bytes.copyOfRange(8, 10))),
+    "files" to listOf(
+      mapOf("length" to 3L, "path" to listOf("first")),
+      mapOf("length" to 4L, "path" to listOf("skip")),
+      mapOf("length" to 3L, "path" to listOf("last"))
+    )
+  ))))
+
+  @Test
+  fun restart_rehashesChangedFilesAndRestoresNoncontiguousSelection() = runTest {
+    val root = root()
+    val store = store(root)
+    try {
+      store.initialize()
+      for (piece in 0..2) store.commit(piece, bytes.copyOfRange(piece * 4, minOf(piece * 4 + 4, 10)))
+      val snapshot = assertNotNull(TorrentCheckpoint.decode(store.persistCheckpoint()))
+      assertEquals(setOf(0, 2), snapshot.selected)
+      torrentFileSystem.write(root / "pack/last") { writeUtf8("bad") }
+      val restarted = store(root)
+      restarted.restore(snapshot)
+      restarted.initialize()
+      assertContentEquals(booleanArrayOf(true, false, false), restarted.recheck())
+      assertContentEquals(longArrayOf(3, 0, 0), restarted.progress())
+      assertFalse(restarted.completed())
+      for (piece in 1..2) restarted.commit(piece,
+        bytes.copyOfRange(piece * 4, minOf(piece * 4 + 4, 10)))
+      restarted.finish()
+      assertTrue(restarted.completed())
+    } finally {
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+
+  @Test
+  fun journal_recoversBeforeTaskStoreCheckpointAndDiscardsTornTail() = runTest {
+    val root = root()
+    try {
+      val initial = store(root)
+      initial.initialize()
+      initial.commit(0, bytes.copyOfRange(0, 4))
+      val journal = root / ".ketch-${metadata.infoHash.hex}-test/ownership"
+      torrentFileSystem.openReadWrite(journal, mustExist = true).use { handle ->
+        val torn = Buffer().writeInt(100).writeUtf8("partial").readByteArray()
+        handle.write(handle.size(), torn, 0, torn.size)
+        handle.flush()
+      }
+      val restarted = store(root)
+      restarted.initialize()
+      assertContentEquals(booleanArrayOf(true, false, false), restarted.recheck())
+      restarted.persistCheckpoint()
+      val deleting = store(root)
+      deleting.recoverOwnership()
+      deleting.cleanup()
+      assertFalse(torrentFileSystem.exists(root / "pack/first"))
+      assertFalse(torrentFileSystem.exists(root / "pack/last"))
+      assertFalse(torrentFileSystem.exists(journal))
+    } finally {
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+
+  @Test
+  fun offlineCleanup_preservesReplacedAndPreexistingFiles() = runTest {
+    val root = root()
+    torrentFileSystem.createDirectories(root / "pack")
+    torrentFileSystem.write(root / "pack/first") { writeUtf8("preexisting") }
+    try {
+      val initial = store(root)
+      initial.initialize()
+      val snapshot = assertNotNull(TorrentCheckpoint.decode(initial.persistCheckpoint()))
+      // Keep the original inode alive, making the replacement's different identity explicit.
+      torrentFileSystem.atomicMove(root / "pack/last", root / "original-owned-file")
+      torrentFileSystem.write(root / "pack/last") { writeUtf8("replacement") }
+      val deleting = store(root)
+      deleting.restore(snapshot)
+      deleting.recoverOwnership()
+      deleting.cleanup()
+      assertEquals("preexisting", torrentFileSystem.read(root / "pack/first") { readUtf8() })
+      assertEquals("replacement", torrentFileSystem.read(root / "pack/last") { readUtf8() })
+    } finally {
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+
+  @Test
+  fun checkpoint_rejectsWrongIdentityAndEscapingOwnershipAndRecognizesLegacy() = runTest {
+    val root = root()
+    try {
+      val initial = store(root)
+      initial.initialize()
+      val snapshot = initial.checkpoint()
+      assertFailsWith<IllegalArgumentException> {
+        store(root).restore(snapshot.copy(taskId = "another-task"))
+      }
+      assertFailsWith<IllegalArgumentException> {
+        store(root).restore(snapshot.copy(files = listOf(TorrentOwnedPath("/outside", "fake"))))
+      }
+      assertNull(TorrentCheckpoint.decode("legacy-native-data".encodeToByteArray()))
+      assertFailsWith<IllegalArgumentException> {
+        TorrentCheckpoint.decode(snapshot.encode().dropLast(1).toByteArray())
+      }
+    } finally {
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+
+  private fun root(): Path = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+    "ketch-checkpoint-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+
+  private fun store(root: Path): TorrentPieceStore =
+    TorrentPieceStore(metadata, root / "pack", setOf(0, 2), "test")
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentCheckpointTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentCheckpointTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.test.runTest
 import okio.Buffer
 import okio.FileSystem
 import okio.Path
+import okio.Path.Companion.toPath
 import okio.use
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -15,6 +16,58 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TorrentCheckpointTest {
+  @Test
+  fun checkpointAboveFourMiBRoundTripsAndStillRejectsSixteenMiBOverflow() {
+    val large = TorrentMetadata.fromBencode(Bencode.encode(mapOf(
+      "comment" to ByteArray(4 * 1024 * 1024 - 256),
+      "info" to mapOf("name" to "empty", "length" to 0L,
+        "piece length" to 1L, "pieces" to ByteArray(0))
+    )))
+    val owned = TorrentOwnedPath("/tmp/" + "a".repeat(500), "identity")
+    val checkpoint = TorrentCheckpoint("test", large, "/tmp/empty", emptySet(), BooleanArray(0),
+      List(10) { owned.copy(path = owned.path + it) }, emptyList())
+    val encoded = checkpoint.encode()
+    assertTrue(encoded.size > 4 * 1024 * 1024)
+    val decoded = assertNotNull(TorrentCheckpoint.decode(encoded))
+    assertEquals(large.infoHash, decoded.metadata.infoHash)
+    assertEquals(checkpoint.files, decoded.files)
+    assertFailsWith<IllegalArgumentException> {
+      checkpoint.copy(files = List(40_000) { owned }).encode()
+    }
+  }
+
+  @Test
+  fun restoringManyOwnedFilesBuildsOutputPathsOnce() = runTest {
+    val parsed = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+      "name" to "pack", "piece length" to 1L, "pieces" to ByteArray(0),
+      "files" to List(1000) { mapOf("path" to listOf("f$it"), "length" to 0L) }
+    ))))
+    var fileLookups = 0
+    val counted = parsed.copy(files = object : AbstractList<TorrentMetadata.TorrentFile>() {
+      override val size = parsed.files.size
+      override fun get(index: Int): TorrentMetadata.TorrentFile {
+        fileLookups++
+        return parsed.files[index]
+      }
+    })
+    val root = root()
+    try {
+      torrentFileSystem.createDirectories(root / "pack")
+      val store = TorrentPieceStore(counted, root / "pack", emptySet(), "test")
+      val records = List(1000) {
+        TorrentOwnedPath((store.outputPath.toPath() / "f$it").toString(), "not-owned")
+      }
+      val checkpoint = TorrentCheckpoint("test", counted, store.outputPath,
+        emptySet(), BooleanArray(0), records, emptyList())
+      fileLookups = 0
+      store.restore(checkpoint)
+      assertTrue(fileLookups < 5000, "Output paths were recomputed $fileLookups times")
+      assertTrue(store.checkpoint().files.isEmpty())
+    } finally {
+      torrentFileSystem.deleteRecursively(root, mustExist = false)
+    }
+  }
+
   private val bytes = "0123456789".encodeToByteArray()
   private val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
     "name" to "pack", "piece length" to 4L,

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentOwnershipJournalTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentOwnershipJournalTest.kt
@@ -1,0 +1,36 @@
+package com.linroid.ketch.torrent
+
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class TorrentOwnershipJournalTest {
+  @Test
+  fun compactionAtomicallyReplacesStaleRecordsAndRetainsItsOwnIdentity() {
+    val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+      "ketch-journal-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+    torrentFileSystem.createDirectories(root)
+    try {
+      val path = root / "ownership"
+      val binding = "task-binding".encodeToByteArray()
+      val journal = TorrentOwnershipJournal(path, binding, torrentFileSystem)
+      journal.initialize()
+      val before = torrentFileIdentity(path)
+      val old = TorrentOwnedPath((root / "old").toString(), "old-identity")
+      val current = TorrentOwnedPath((root / "current").toString(), "current-identity")
+      journal.append(false, old)
+      journal.append(false, current)
+      val identity = journal.compact(listOf(false to current))
+      assertNotEquals(before, identity)
+      assertEquals(torrentFileIdentity(path), identity)
+      val restored = TorrentOwnershipJournal(path, binding, torrentFileSystem).load()
+      assertTrue(restored.none { it.second == old })
+      assertEquals(setOf(current, TorrentOwnedPath(path.toString(), identity)),
+        restored.map { it.second }.toSet())
+    } finally {
+      torrentFileSystem.deleteRecursively(root)
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentRateLimiterTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentRateLimiterTest.kt
@@ -1,0 +1,32 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TorrentRateLimiterTest {
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  @Test
+  fun limit_enforcesSustainedRateAndRemovingLimitUnblocksWaiters() = runTest {
+    val limiter = TorrentRateLimiter(1024) { testScheduler.currentTime }
+    limiter.acquire(16_384)
+    val transfer = async { limiter.acquire(1024) }
+    advanceTimeBy(900)
+    assertFalse(transfer.isCompleted)
+    advanceTimeBy(150)
+    runCurrent()
+    assertTrue(transfer.isCompleted)
+    limiter.set(1)
+    val waiting = async { limiter.acquire(16_384) }
+    advanceTimeBy(100)
+    assertFalse(waiting.isCompleted)
+    limiter.set(0)
+    advanceTimeBy(50)
+    runCurrent()
+    assertTrue(waiting.isCompleted)
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmReviewTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentSwarmReviewTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -17,6 +18,49 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TorrentSwarmReviewTest {
+  @Test
+  fun payloadLimiterWaitLongerThanBlockDeadlineStillCompletes() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(40_000) {
+        coroutineScope {
+          val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+            "ketch-slow-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+          val metadata = metadata(byteArrayOf(1))
+          val store = TorrentPieceStore(metadata, root / "file", emptySet(), "test")
+          val network = createTorrentNetwork()
+          val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+          val server = launch {
+            val connection = listener.accept()
+            try {
+              val wire = PeerWire(connection, metadata)
+              wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+              wire.send(PeerMessage.Have(0))
+              wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+              while (wire.read() !is PeerMessage.Request) { }
+              wire.send(PeerMessage.Piece(0, 0, byteArrayOf(1)))
+              awaitCancellation()
+            } finally {
+              connection.close()
+            }
+          }
+          val peers = Channel<PeerEndpoint>(1)
+          peers.send(listener.local)
+          peers.close()
+          val budget = TorrentBufferBudget(1024 * 1024)
+          try {
+            TorrentSwarm(store, network, budget, downloadPayload = { delay(21_000) }).run(peers)
+            assertTrue(store.completed())
+            assertEquals(0, budget.allocated)
+          } finally {
+            server.cancelAndJoin()
+            network.close()
+            torrentFileSystem.deleteRecursively(root, mustExist = false)
+          }
+        }
+      }
+    }
+  }
+
   private fun metadata(bytes: ByteArray) = TorrentMetadata.fromBencode(Bencode.encode(
     mapOf("info" to mapOf("name" to "file", "length" to bytes.size.toLong(),
       "piece length" to 1L, "pieces" to if (bytes.isEmpty()) ByteArray(0) else sha1Digest(bytes)))

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/TorrentFileIdentity.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/TorrentFileIdentity.ios.kt
@@ -1,0 +1,19 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import okio.Path
+import platform.posix.S_IFLNK
+import platform.posix.S_IFMT
+import platform.posix.lstat
+import platform.posix.stat
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun torrentFileIdentity(path: Path): String? = memScoped {
+  val attributes = alloc<stat>()
+  if (lstat(path.toString(), attributes.ptr) != 0 ||
+    attributes.st_mode.toInt() and S_IFMT == S_IFLNK) return@memScoped null
+  "${attributes.st_dev}:${attributes.st_ino}"
+}

--- a/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/TorrentFileIdentity.jvmAndAndroid.kt
+++ b/library/torrent/src/jvmAndAndroidMain/kotlin/com/linroid/ketch/torrent/TorrentFileIdentity.jvmAndAndroid.kt
@@ -1,0 +1,15 @@
+package com.linroid.ketch.torrent
+
+import okio.Path
+import java.nio.file.Files
+import java.nio.file.LinkOption
+import java.nio.file.NoSuchFileException
+import java.nio.file.Paths
+import java.nio.file.attribute.BasicFileAttributes
+
+internal actual fun torrentFileIdentity(path: Path): String? = try {
+  Files.readAttributes(Paths.get(path.toString()), BasicFileAttributes::class.java,
+    LinkOption.NOFOLLOW_LINKS).let { if (it.isSymbolicLink) null else it.fileKey()?.toString() }
+} catch (_: NoSuchFileException) {
+  null
+}

--- a/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/TorrentProcessCrashTest.kt
+++ b/library/torrent/src/jvmTest/kotlin/com/linroid/ketch/torrent/TorrentProcessCrashTest.kt
@@ -1,0 +1,107 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import okio.FileHandle
+import okio.ForwardingFileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TorrentProcessCrashTest {
+  @Test
+  fun processExitDuringPieceWrite_rechecksPartialBytesAndRecoversOwnership() = runTest {
+    crash("write")
+  }
+
+  @Test
+  fun processExitBeforeTaskStoreCheckpoint_recoversFlushedPiece() = runTest {
+    crash("before-checkpoint")
+  }
+
+  @Test
+  fun processExitAfterAtomicCheckpoint_keepsRecoverableOwnership() = runTest {
+    crash("checkpoint")
+  }
+
+  private suspend fun crash(mode: String) = withContext(Dispatchers.IO) {
+    val root = Files.createTempDirectory("ketch-crash").toFile()
+    root.resolve("neighbor").writeText("keep")
+    try {
+      val urls = generateSequence(javaClass.classLoader) { it.parent }
+        .filterIsInstance<URLClassLoader>().flatMap { it.urLs.asSequence() }
+        .map { File(it.toURI()).absolutePath }.toList()
+      val classpath = (urls + System.getProperty("java.class.path").split(File.pathSeparator))
+        .distinct().joinToString(File.pathSeparator)
+      val process = ProcessBuilder(File(System.getProperty("java.home"), "bin/java").absolutePath,
+        "-cp", classpath, "com.linroid.ketch.torrent.CrashingTorrentProcess", root.absolutePath, mode)
+        .redirectErrorStream(true).redirectOutput(root.resolve("child.log")).start()
+      val exited = process.waitFor(20, TimeUnit.SECONDS)
+      if (!exited) process.destroyForcibly()
+      assertTrue(exited, "Child process did not exit")
+      assertEquals(73, process.exitValue(), root.resolve("child.log").readText().take(4000))
+      val store = TorrentPieceStore(CrashingTorrentProcess.metadata(),
+        root.resolve("payload").absolutePath.toPath(), emptySet(), "crash")
+      store.initialize()
+      assertContentEquals(booleanArrayOf(mode != "write", false), store.recheck())
+      store.cleanup()
+      assertFalse(root.resolve("payload").exists())
+      assertEquals("keep", root.resolve("neighbor").readText())
+    } finally {
+      root.deleteRecursively()
+    }
+  }
+}
+
+/** Deliberately exits without running Kotlin cleanup at controlled filesystem boundaries. */
+internal object CrashingTorrentProcess {
+  fun metadata(): TorrentMetadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+    "name" to "payload", "length" to 8L, "piece length" to 4L,
+    "pieces" to (sha1Digest(byteArrayOf(1, 2, 3, 4)) + sha1Digest(byteArrayOf(5, 6, 7, 8)))
+  ))))
+
+  @JvmStatic
+  fun main(args: Array<String>): Unit = runBlocking {
+    val output = args[0].toPath() / "payload"
+    val mode = args[1]
+    val fs = object : ForwardingFileSystem(torrentFileSystem) {
+      override fun openReadWrite(file: Path, mustCreate: Boolean, mustExist: Boolean): FileHandle {
+        val delegate = super.openReadWrite(file, mustCreate, mustExist)
+        if (file.name != "payload" || mode != "write") return delegate
+        return object : FileHandle(readWrite = true) {
+          override fun protectedRead(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int =
+            delegate.read(fileOffset, array, arrayOffset, byteCount)
+          override fun protectedWrite(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int) {
+            delegate.write(fileOffset, array, arrayOffset, maxOf(1, byteCount / 2))
+            delegate.flush()
+            Runtime.getRuntime().halt(73)
+          }
+          override fun protectedFlush() = delegate.flush()
+          override fun protectedResize(size: Long) = delegate.resize(size)
+          override fun protectedSize(): Long = delegate.size()
+          override fun protectedClose() = delegate.close()
+        }
+      }
+      override fun atomicMove(source: Path, target: Path) {
+        super.atomicMove(source, target)
+        if (mode == "checkpoint" && target.name == "checkpoint") Runtime.getRuntime().halt(73)
+      }
+    }
+    val store = TorrentPieceStore(metadata(), output, emptySet(), "crash", fs)
+    store.initialize()
+    store.commit(0, byteArrayOf(1, 2, 3, 4))
+    if (mode == "before-checkpoint") Runtime.getRuntime().halt(73)
+    store.persistCheckpoint()
+    error("Crash boundary was not reached")
+  }
+}


### PR DESCRIPTION
Adds versioned Kotlin checkpoints with metainfo, selection, output mapping, verified-piece hints, network counters and OS file identities. Restart rehashes actual output. An append-only ownership journal survives gaps between file writes and TaskStore snapshots, repairs torn final appends, and compacts atomically. Offline cleanup preserves preexisting/replaced files and deletes its journal last.

Adds task-isolated Kotlin sessions with pause/resume, observable failure and verified progress, durable completion snapshots, and live rate/connection controls. Fixes concurrent parent-directory creation and makes Darwin socket disconnects report IOException consistently.

Validation: torrent tests pass on JVM, Android host and iOS simulator. Tests cover changed/missing output, noncontiguous selection, torn journals, compaction, malformed/legacy state, identity-safe deletion, and pausing one of two active torrents. JVM child processes halt without cleanup during piece writes, before TaskStore checkpoint publication and after atomic checkpoint replacement; recovery rehashes correctly and preserves unrelated files.

Ownership is deliberately conservative: an interrupted creation before its identity record, or an unknown temporary metadata file, may be preserved rather than inferred to belong to the task. Concurrent symlink replacement remains a final storage-hardening audit.

Layer 12 of the approved stack, based on #158. Public Ketch/runtime wiring follows in layer 13.
