### PR TITLE
feat(torrent): integrate the Kotlin runtime across supported products

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
   implementation(projects.library.sqlite)
   implementation(projects.library.ktor)
   implementation(projects.library.ftp)
+  implementation(projects.library.torrent)
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.ktor.client.cio)

--- a/cli/src/main/kotlin/com/linroid/ketch/cli/Main.kt
+++ b/cli/src/main/kotlin/com/linroid/ketch/cli/Main.kt
@@ -165,6 +165,7 @@ fun main(args: Array<String>) {
   val ketch = Ketch(
     httpEngine = KtorHttpEngine(),
     config = config,
+    additionalSources = listOf(FtpDownloadSource(), TorrentDownloadSource()),
   )
 
   runBlocking {

--- a/cli/src/main/kotlin/com/linroid/ketch/cli/Main.kt
+++ b/cli/src/main/kotlin/com/linroid/ketch/cli/Main.kt
@@ -22,6 +22,7 @@ import com.linroid.ketch.config.defaultDbPath
 import com.linroid.ketch.config.generateConfig
 import com.linroid.ketch.core.Ketch
 import com.linroid.ketch.engine.KtorHttpEngine
+import com.linroid.ketch.torrent.TorrentDownloadSource
 import com.linroid.ketch.ftp.FtpDownloadSource
 import com.linroid.ketch.mcp.KetchMcpServer
 import com.linroid.ketch.server.KetchServer
@@ -431,7 +432,7 @@ private fun runServer(args: Array<String>) {
     config = downloadConfig,
     name = instanceName,
     logger = Logger.console(ketchLogLevel),
-    additionalSources = listOf(FtpDownloadSource())
+    additionalSources = listOf(FtpDownloadSource(), TorrentDownloadSource())
   )
   val server = KetchServer(
     ketch,
@@ -647,7 +648,7 @@ private fun runMcp(args: List<String>) {
     taskStore = taskStore,
     config = downloadConfig,
     logger = Logger.console(ketchLogLevel),
-    additionalSources = listOf(FtpDownloadSource()),
+    additionalSources = listOf(FtpDownloadSource(), TorrentDownloadSource()),
   )
 
   Runtime.getRuntime().addShutdownHook(Thread {

--- a/docs/plans/pure-kotlin-torrent-progress.md
+++ b/docs/plans/pure-kotlin-torrent-progress.md
@@ -16,10 +16,11 @@ Approved scope: [roadmap](pure-kotlin-torrent-roadmap.md). Implementation checko
 | 09 Magnet metadata | https://github.com/linroid/Ketch/pull/156 | Independent seeder metadata-to-payload transfer; common negotiation, hash/size/private validation and shared cache tests |
 | 10 DHT foundations | https://github.com/linroid/Ketch/pull/157 | Published BEP 42/CRC vectors, routing/token expiry, packet quotas and IPv4/IPv6 RPC correlation |
 | 11 Trackerless discovery and PEX | https://github.com/linroid/Ketch/pull/158 | IPv4/IPv6 multi-hop/warm DHT, PEX payload discovery, public identity quorum, private-source policy; independent DHT-to-metadata-to-payload JVM transfer |
-| 12 Durable resume | Pending PR | Journal/checkpoint/identity recovery, concurrent session pause/resume and live limits pass on JVM/Android/iOS; JVM process-crash fixtures pass at write/checkpoint boundaries |
-| 13–14 | Pending | Not implemented yet |
+| 12 Durable resume | https://github.com/linroid/Ketch/pull/159 | Journal/checkpoint/identity recovery, concurrent session pause/resume and live limits pass on JVM/Android/iOS; JVM process-crash fixtures pass at write/checkpoint boundaries |
+| 13 Kotlin runtime and product integration | Pending PR | Kotlin default on JVM/Android/iOS; CLI download/daemon registration; public-source selected boundary transfer and offline recovery, incoming seeding, connection reduction, and final checkpoint handoff |
+| 14 Hardening and native removal | Pending | Final interoperability, security/performance/artifact gates and removal remain |
 
-No PR has been merged. The default transfer engine is still libtorrent4j.
+No PR has been merged. The default transfer engine is now Kotlin; native code remains temporarily for comparison until layer 14.
 
 Implementation notes:
 
@@ -31,9 +32,9 @@ Implementation notes:
 - Bencode and SHA-1 use common Kotlin. Platform Unicode normalization is used only to reject
   filesystem name collisions; torrent identity hashes the original metainfo bytes.
 - The storage layer refuses symlink child paths and tracks files created by the task. Durable
-  ownership recovery and crash-safe resume remain layer 12 work.
+  ownership recovery and crash-safe resume are implemented in layer 12.
 - Common tests use hand-written fakes. Protocol interoperability with an independent seeder
-  starts at layer 06; production source/runtime integration remains gated until layer 13.
+  starts at layer 06; production source/runtime integration is implemented in layer 13.
 
 - Ownership records include OS file identity and are appended independently of TaskStore snapshots.
   Cleanup preserves paths whose identity cannot be proven. A process exit in the tiny interval

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadContext.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadContext.kt
@@ -49,4 +49,6 @@ class DownloadContext(
   var pendingResegment: Int = 0,
   /** Final destination resolved by Ketch, including default directory and deduplication. */
   val outputPath: String? = null,
+  /** Optional payload speed for sources whose verified progress advances in whole pieces. */
+  val reportedSpeed: MutableStateFlow<Long?> = MutableStateFlow(null),
 )

--- a/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadExecution.kt
+++ b/library/core/src/commonMain/kotlin/com/linroid/ketch/core/engine/DownloadExecution.kt
@@ -1,5 +1,6 @@
 package com.linroid.ketch.core.engine
 
+import com.linroid.ketch.api.FileSelectionMode
 import com.linroid.ketch.api.DownloadConfig
 import com.linroid.ketch.api.DownloadProgress
 import com.linroid.ketch.api.DownloadState
@@ -23,6 +24,7 @@ import com.linroid.ketch.core.task.TaskRecord
 import com.linroid.ketch.core.task.TaskState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -127,7 +129,16 @@ internal class DownloadExecution(
       resolvedUrl = source.resolve(request.url, request.headers)
     }
 
-    val total = resolvedUrl.totalBytes
+    val total = if (resolvedUrl.selectionMode == FileSelectionMode.MULTIPLE &&
+      request.selectedFileIds.isNotEmpty()) {
+      require(request.selectedFileIds.all { id -> resolvedUrl.files.any { it.id == id } }) {
+        "Unknown selected file"
+      }
+      resolvedUrl.files.filter { it.id in request.selectedFileIds }.fold(0L) { sum, file ->
+        require(file.size >= 0 && sum <= Long.MAX_VALUE - file.size)
+        sum + file.size
+      }
+    } else resolvedUrl.totalBytes
     if (total < 0) {
       log.e { "Unknown file size for ${request.url}" }
       throw KetchError.SourceError(
@@ -149,7 +160,7 @@ internal class DownloadExecution(
     )
     log.d { "Resolved outputPath=$outputPath" }
 
-    if (total == 0L) {
+    if (total == 0L && !source.managesOwnFileIo) {
       completeZeroByteFile(outputPath, source.type)
       return
     }
@@ -258,7 +269,15 @@ internal class DownloadExecution(
         try {
           downloadWithRetry(ctx) { downloadBlock(ctx) }
         } finally {
-          saveJob.cancel()
+          withContext(NonCancellable) {
+            saveJob.cancelAndJoin()
+            val updatedResume = source.updateResumeState(ctx)
+            handle.record.update {
+              it.copy(segments = handle.mutableSegments.value,
+                sourceResumeState = updatedResume ?: it.sourceResumeState,
+                updatedAt = Clock.System.now())
+            }
+          }
         }
       }
 
@@ -434,6 +453,7 @@ internal class DownloadExecution(
     var lastBytes = 0L
     var lastMark = TimeSource.Monotonic.markNow()
     var speed = 0L
+    val reportedSpeed = MutableStateFlow<Long?>(null)
     return DownloadContext(
       taskId = taskId,
       url = request.url,
@@ -450,7 +470,7 @@ internal class DownloadExecution(
           lastMark = now
         }
         handle.mutableState.value = DownloadState.Downloading(
-          DownloadProgress(downloaded, total, speed),
+          DownloadProgress(downloaded, total, reportedSpeed.value ?: speed),
         )
       },
       throttle = { bytes ->
@@ -460,6 +480,7 @@ internal class DownloadExecution(
       headers = request.headers,
       preResolved = preResolved,
       outputPath = outputPath,
+      reportedSpeed = reportedSpeed,
       maxConnections = MutableStateFlow(
         request.connections.takeIf { it > 0 } ?: 0,
       ),

--- a/library/core/src/commonTest/kotlin/com/linroid/ketch/engine/SelfManagedExecutionTest.kt
+++ b/library/core/src/commonTest/kotlin/com/linroid/ketch/engine/SelfManagedExecutionTest.kt
@@ -1,0 +1,90 @@
+package com.linroid.ketch.engine
+
+import com.linroid.ketch.api.Destination
+import com.linroid.ketch.api.DownloadConfig
+import com.linroid.ketch.api.DownloadRequest
+import com.linroid.ketch.api.DownloadState
+import com.linroid.ketch.api.FileSelectionMode
+import com.linroid.ketch.api.ResolvedSource
+import com.linroid.ketch.api.Segment
+import com.linroid.ketch.api.SourceFile
+import com.linroid.ketch.core.KetchDispatchers
+import com.linroid.ketch.core.engine.DownloadContext
+import com.linroid.ketch.core.engine.DownloadExecution
+import com.linroid.ketch.core.engine.DownloadSource
+import com.linroid.ketch.core.engine.SourceResolver
+import com.linroid.ketch.core.engine.SourceResumeState
+import com.linroid.ketch.core.engine.SpeedLimiter
+import com.linroid.ketch.core.file.DefaultFileNameResolver
+import com.linroid.ketch.core.task.AtomicSaver
+import com.linroid.ketch.core.task.TaskHandle
+import com.linroid.ketch.core.task.TaskRecord
+import com.linroid.ketch.core.task.TaskState
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+
+class SelfManagedExecutionTest {
+  @Test
+  fun zeroByteSelectionReachesSourceAndCancellationSavesFinalState() = runTest {
+    val started = CompletableDeferred<Unit>()
+    var finalState = false
+    var calls = 0
+    val source = object : DownloadSource {
+      override val type = "fixture"
+      override val managesOwnFileIo = true
+      override fun canHandle(url: String) = true
+      override suspend fun resolve(url: String, properties: Map<String, String>) = ResolvedSource(
+        url = url, sourceType = type, totalBytes = 100, supportsResume = true,
+        suggestedFileName = "fixture", maxSegments = 2,
+        files = listOf(SourceFile("0", "empty", 0), SourceFile("1", "other", 100)),
+        selectionMode = FileSelectionMode.MULTIPLE,
+      )
+      override fun buildResumeState(resolved: ResolvedSource, totalBytes: Long): SourceResumeState {
+        assertEquals(0L, totalBytes)
+        return SourceResumeState(type, "initial")
+      }
+      override suspend fun updateResumeState(context: DownloadContext): SourceResumeState {
+        calls++
+        assertTrue(finalState)
+        return SourceResumeState(type, "final")
+      }
+      override suspend fun download(context: DownloadContext) {
+        assertEquals("/tmp/ketch-self-managed-output", context.outputPath)
+        started.complete(Unit)
+        try { awaitCancellation() } finally { finalState = true }
+      }
+      override suspend fun resume(context: DownloadContext, resumeState: SourceResumeState) = Unit
+    }
+    val now = Clock.System.now()
+    val request = DownloadRequest("fixture:input", selectedFileIds = setOf("0"),
+      destination = Destination("/tmp/ketch-self-managed-output"))
+    val handle = object : TaskHandle {
+      override val taskId = "self-managed"
+      override val request = request
+      override val createdAt = now
+      override val mutableState = MutableStateFlow<DownloadState>(DownloadState.Queued)
+      override val mutableSegments = MutableStateFlow<List<Segment>>(emptyList())
+      override val record = AtomicSaver(TaskRecord(taskId, request, state = TaskState.QUEUED,
+        createdAt = now, updatedAt = now)) {}
+    }
+    val execution = DownloadExecution(handle, SourceResolver(listOf(source)),
+      DefaultFileNameResolver(), DownloadConfig(saveIntervalMs = 60_000), SpeedLimiter.Unlimited,
+      KetchDispatchers(main = Dispatchers.Default, network = Dispatchers.Default,
+        io = Dispatchers.Default))
+    val job = launch { execution.execute() }
+    started.await()
+    assertEquals(0L, execution.totalBytes)
+    job.cancelAndJoin()
+    assertEquals(1, calls)
+    assertEquals("final", handle.record.value.sourceResumeState?.data)
+  }
+}

--- a/library/torrent/src/androidMain/kotlin/com/linroid/ketch/torrent/PlatformActuals.android.kt
+++ b/library/torrent/src/androidMain/kotlin/com/linroid/ketch/torrent/PlatformActuals.android.kt
@@ -1,5 +1,4 @@
 package com.linroid.ketch.torrent
 
-internal actual fun createTorrentEngine(
-  config: TorrentConfig,
-): TorrentEngine = createLibtorrent4jEngine(config)
+internal actual fun createTorrentEngine(config: TorrentConfig): TorrentEngine =
+  KotlinTorrentEngine(config)

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/KotlinTorrentEngine.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/KotlinTorrentEngine.kt
@@ -1,0 +1,346 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/** Source-owned Kotlin runtime. Task jobs borrow its bounded transports and discovery services. */
+@OptIn(ExperimentalAtomicApi::class, kotlinx.coroutines.ExperimentalCoroutinesApi::class,
+  kotlinx.coroutines.DelicateCoroutinesApi::class)
+internal class KotlinTorrentEngine(
+  private val config: TorrentConfig,
+  rawNetwork: TorrentNetwork = createTorrentNetwork(),
+  private val http: TorrentHttp = TorrentHttp.default(),
+) : TorrentEngine {
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private val network = TorrentConnectionBudget(rawNetwork, config.maxConnections)
+  private val budget = TorrentBufferBudget(config.maxBufferedBytes)
+  private val cache = TorrentMetadataCache(scope)
+  private val tracker = TorrentTracker(http, network)
+  private val peerId = torrentRandomBytes(20)
+  private val mutex = Mutex()
+  private val dhtMutex = Mutex()
+  private val sessions = mutableMapOf<String, KotlinTorrentSession>()
+  private val outputs = mutableMapOf<String, String>()
+  private val running = AtomicBoolean(false)
+  private var closed = false
+  private var port = 0
+  val listenPort: Int get() = port
+  private var nodes: List<DhtNode>? = null
+  private val downloadRate = TorrentRateLimiter()
+  private val uploadRate = TorrentRateLimiter()
+  override val isRunning: Boolean get() = running.load()
+
+  override suspend fun start() = mutex.withLock {
+    check(!closed) { "Torrent runtime is closed" }
+    if (running.load()) return@withLock
+    val listener = network.listen(PeerEndpoint("0.0.0.0", config.listenPort))
+    port = listener.local.port
+    running.store(true)
+    accept(listener)
+    // Some systems provide dual-stack sockets and reject a second bind on the same port.
+    try { accept(network.listen(PeerEndpoint("::", port))) } catch (_: Exception) {
+      currentCoroutineContext().let { if (!it.isActive) throw CancellationException() }
+    }
+  }
+
+  private fun accept(listener: TorrentListener) = scope.launch {
+    try {
+      while (isActive) {
+        val connection = listener.accept()
+        launch(start = CoroutineStart.ATOMIC) {
+          var handedOff = false
+          try {
+            val bytes = withTimeout(10_000) { connection.readExactly(68) }
+            val hash = InfoHash.fromBytes(bytes.copyOfRange(28, 48))
+            PeerWire.decodeHandshake(bytes, hash)
+            // Replay the already bounded handshake through the ordinary peer worker.
+            val replay = object : TorrentConnection by connection {
+              var header: ByteArray? = bytes
+              override suspend fun readExactly(size: Int): ByteArray {
+                val first = header
+                if (first == null) return connection.readExactly(size)
+                require(size == first.size)
+                header = null
+                return first
+              }
+            }
+            handedOff = mutex.withLock { sessions[hash.hex]?.accept(replay) == true }
+          } catch (e: CancellationException) {
+            throw e
+          } catch (_: Exception) {
+            // Malformed, unknown, or expired handshakes are isolated to this connection.
+          } finally {
+            if (!handedOff) connection.close()
+          }
+        }
+      }
+    } finally { listener.close() }
+  }
+
+  override fun close() {
+    running.store(false)
+    scope.cancel()
+    network.close()
+    http.close()
+  }
+
+  override suspend fun stop() {
+    val active = mutex.withLock {
+      if (closed) return
+      closed = true
+      running.store(false)
+      sessions.values.toList().also { sessions.clear(); outputs.clear() }
+    }
+    withContext(NonCancellable) {
+      try {
+        active.forEach { it.pause(); it.close() }
+        nodes?.forEach { it.close() }
+      } finally {
+        scope.cancel()
+        network.close()
+        http.close()
+      }
+    }
+  }
+
+  override suspend fun fetchMetadata(magnetUri: String): TorrentMetadata? {
+    check(isRunning)
+    val magnet = MagnetUri.parse(magnetUri)
+    val metadata = cache.resolve(magnet.infoHash) {
+      withTimeout(config.metadataTimeout) {
+        coroutineScope {
+          val peers = Channel<PeerEndpoint>(256)
+          val discovery = launch { discoverMagnet(magnet, peers) }
+          val attempted = mutableSetOf<PeerEndpoint>()
+          try {
+            while (true) {
+              val endpoint = peers.receive()
+              if (!attempted.add(endpoint)) continue
+              if (attempted.size > 4096) error("Metadata peer limit exceeded")
+              try {
+                return@coroutineScope TorrentMetadataExchange(network, config.maxMetadataBytes,
+                  budget = budget).fetch(magnet.infoHash, endpoint)
+              } catch (e: PrivateTorrentMagnetException) {
+                throw e
+              } catch (e: CancellationException) {
+                if (!currentCoroutineContext().isActive) throw e
+              } catch (_: Exception) {
+                // A bad peer must not prevent trying the remaining discovery candidates.
+              }
+            }
+            @Suppress("UNREACHABLE_CODE")
+            error("No metadata peers")
+          } finally { discovery.cancel(); peers.cancel() }
+        }
+      }
+    }
+    // Cache the immutable info dictionary, retaining this caller's tracker list.
+    return TorrentMetadata.fromBencode(metainfoFromInfo(metadata.infoBytes,
+      magnet.trackers.map { listOf(it) }), config.maxMetadataBytes)
+  }
+
+  private suspend fun discoverMagnet(magnet: MagnetUri, output: SendChannel<PeerEndpoint>) =
+    supervisorScope {
+      launch {
+        for (text in magnet.explicitPeers) {
+          resolveEndpoint(text).forEach { output.send(it) }
+        }
+      }
+      if (magnet.trackers.isNotEmpty()) launch {
+        val tiers = TrackerTiers(magnet.trackers.map { listOf(it) }, tracker::announce)
+        while (isActive) {
+          val result = attempt {
+            tiers.announce(TrackerAnnounce(magnet.infoHash, peerId, port, 0, 1,
+              event = TrackerEvent.STARTED))
+          }
+          result?.peers?.forEach { output.send(it) }
+          delay((result?.intervalSeconds ?: 30) * 1000)
+        }
+      }
+      if (config.dhtEnabled) launch {
+        while (isActive) {
+          dhtPeers(magnet.infoHash, announce = false).forEach { output.send(it) }
+          delay(30_000)
+        }
+      }
+    }
+
+  override suspend fun addTorrent(
+    infoHash: String,
+    savePath: String,
+    magnetUri: String?,
+    torrentData: ByteArray?,
+    selectedFileIndices: Set<Int>,
+    resumeData: ByteArray?,
+  ): TorrentSession {
+    val metadata = torrentData?.let { TorrentMetadata.fromBencode(it) }
+      ?: magnetUri?.let { fetchMetadata(it) } ?: error("Torrent metainfo is required")
+    require(metadata.infoHash.hex == infoHash)
+    return addTask(TorrentTaskSpec(infoHash, metadata,
+      (savePath.toPath() / metadata.name).toString(), selectedFileIndices, magnetUri, resumeData))
+  }
+
+  override suspend fun addTask(spec: TorrentTaskSpec): KotlinTorrentSession = mutex.withLock {
+    check(isRunning && !closed)
+    check(sessions.size < config.maxActiveTorrents) { "Too many active torrents" }
+    val hash = spec.metadata.infoHash.hex
+    check(hash !in sessions) { "Torrent already has an active owner" }
+    val output = FileSystem.SYSTEM.canonicalize(".".toPath()).resolve(spec.outputPath).normalized()
+    check(outputs.values.none { previous ->
+      val path = previous.toPath()
+      output == path || output.toString().startsWith("$path/") ||
+        path.toString().startsWith("$output/")
+    }) { "Torrent output overlaps another task" }
+    val checkpoint = spec.resumeData?.let(TorrentCheckpoint::decode)
+    val store = TorrentPieceStore(spec.metadata, output, spec.selected, spec.taskId)
+    val session = KotlinTorrentSession(store, network, budget, scope,
+      connections = config.connectionsPerTorrent, uploadPolicy = config.effectiveUploadPolicy,
+      checkpoint = checkpoint, peerId = peerId,
+      discover = { peers, owner -> discover(spec, peers, owner) },
+      downloadThrottle = { downloadRate.acquire(it); spec.throttle(it) },
+      uploadThrottle = { uploadRate.acquire(it) },
+    )
+    sessions[hash] = session
+    outputs[hash] = output.toString()
+    session
+  }
+
+  private suspend fun discover(
+    spec: TorrentTaskSpec,
+    output: SendChannel<PeerEndpoint>,
+    session: KotlinTorrentSession,
+  ) = supervisorScope {
+    val metadata = spec.metadata
+    if (metadata.trackerTiers.isNotEmpty()) launch {
+      val discovery = TrackerDiscovery(metadata, peerId, port,
+        TrackerTiers(metadata.trackerTiers, tracker::announce), session::resetPeers,
+        announceCompletion = spec.selected.isEmpty() || spec.selected.size == metadata.files.size)
+      try {
+        while (isActive) {
+          attempt {
+            discovery.poll(session.verifiedPieces(), session.receivedBytes, session.uploadedBytes)
+          }?.peers?.let { peers ->
+            session.trackerPeers(peers)
+            peers.forEach { output.send(it) }
+          }
+          delay(1000)
+        }
+      } finally {
+        withContext(NonCancellable) {
+          withTimeoutOrNull(2000) {
+            if (session.state.value == TorrentSessionState.FINISHED ||
+              session.state.value == TorrentSessionState.SEEDING) {
+              attempt { discovery.poll(session.verifiedPieces(), session.receivedBytes,
+                session.uploadedBytes) }
+            }
+            attempt { discovery.poll(session.verifiedPieces(), session.receivedBytes,
+              session.uploadedBytes, stopped = true) }
+          }
+        }
+      }
+    }
+    if (!metadata.isPrivate) {
+      spec.magnetUri?.let { uri -> launch {
+        MagnetUri.parse(uri).explicitPeers.forEach { text ->
+          resolveEndpoint(text).forEach { output.send(it) }
+        }
+      } }
+      if (config.dhtEnabled) launch {
+        while (isActive) {
+          dhtPeers(metadata.infoHash, announce = true).forEach { output.send(it) }
+          delay(60_000)
+        }
+      }
+    }
+  }
+
+  private suspend fun dhtPeers(hash: InfoHash, announce: Boolean): List<PeerEndpoint> =
+    supervisorScope {
+      dht().map { node -> async { attempt { node.peers(hash, if (announce) port else null) }
+        ?: emptyList() } }.awaitAll().flatten().distinct()
+    }
+
+  private suspend fun dht(): List<DhtNode> = dhtMutex.withLock {
+    nodes?.let { return@withLock it }
+    val result = mutableListOf<DhtNode>()
+    for (host in listOf("0.0.0.0", "::")) {
+      val node = attempt { DhtNode(network.bindUdp(PeerEndpoint(host, 0)), scope) } ?: continue
+      result.add(node)
+      scope.launch {
+        val snapshot = config.stateDirectory?.toPath()?.resolve(
+          if (':' in host) "dht6.nodes" else "dht4.nodes")
+        val restored = snapshot?.let { path -> attempt {
+          require((FileSystem.SYSTEM.metadata(path).size ?: Long.MAX_VALUE) <= 256 * 1024)
+          DhtRoutingTable.restore(FileSystem.SYSTEM.read(path) { readByteArray() })
+            .second.map { it.endpoint }
+        } } ?: emptyList()
+        val endpoints = config.dhtBootstrap.flatMap { attempt { resolveEndpoint(it) }
+          ?: emptyList() }.filter { (':' in it.host) == (':' in host) }
+        attempt { node.bootstrap((restored + endpoints).distinct().take(64)) }
+        while (isActive) {
+          if (snapshot != null) attempt {
+            FileSystem.SYSTEM.createDirectories(checkNotNull(snapshot.parent))
+            val temporary = snapshot.parent!! / "${snapshot.name}.tmp"
+            val bytes = node.snapshot()
+            FileSystem.SYSTEM.write(temporary) { write(bytes) }
+            FileSystem.SYSTEM.atomicMove(temporary, snapshot)
+          }
+          delay(15 * 60_000)
+          attempt { node.refresh() }
+        }
+      }
+    }
+    nodes = result
+    result
+  }
+
+  override suspend fun removeTorrent(infoHash: String, deleteFiles: Boolean) {
+    mutex.withLock {
+      sessions[infoHash]?.close(deleteFiles)
+      sessions.remove(infoHash)
+      outputs.remove(infoHash)
+    }
+  }
+
+  override fun setDownloadRateLimit(bytesPerSecond: Long) = downloadRate.set(bytesPerSecond)
+  override fun setUploadRateLimit(bytesPerSecond: Long) = uploadRate.set(bytesPerSecond)
+  fun setConnections(value: Int) = network.set(value)
+}
+
+private suspend fun <T> attempt(block: suspend () -> T): T? = try {
+  block()
+} catch (e: CancellationException) {
+  if (!currentCoroutineContext().isActive) throw e
+  null
+} catch (_: Exception) { null }
+
+internal suspend fun resolveEndpoint(value: String): List<PeerEndpoint> {
+  val port = value.substringAfterLast(':').toIntOrNull()
+  require(port != null && port in 1..65535) { "Invalid peer endpoint" }
+  val host = value.substringBeforeLast(':').removeSurrounding("[", "]")
+  return resolveTorrentHost(host).map { PeerEndpoint(numericHost(it), port) }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/KotlinTorrentSession.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/KotlinTorrentSession.kt
@@ -1,5 +1,6 @@
 package com.linroid.ketch.torrent
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -19,6 +20,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -32,6 +34,7 @@ internal class KotlinTorrentSession(
   connections: Int = 20,
   private val uploadPolicy: TorrentUploadPolicy = TorrentUploadPolicy.DISABLED,
   private val checkpoint: TorrentCheckpoint? = null,
+  private val peerId: ByteArray = torrentRandomBytes(20),
   private val discover: suspend (SendChannel<PeerEndpoint>, KotlinTorrentSession) -> Unit,
   private val downloadThrottle: suspend (Int) -> Unit = {},
   private val uploadThrottle: suspend (Int) -> Unit = {},
@@ -41,7 +44,30 @@ internal class KotlinTorrentSession(
   private val scope = CoroutineScope(parent.coroutineContext +
     SupervisorJob(parent.coroutineContext[Job]) + Dispatchers.Default)
   private val lifecycle = Mutex()
+  private val incoming = Channel<TorrentConnection>(16, onUndeliveredElement = { it.close() })
+  private val resets = Channel<CompletableDeferred<Unit>>(1)
+
+  private val allowedPrivateHosts = AtomicReference<Set<String>>(emptySet())
+
+  fun trackerPeers(peers: List<PeerEndpoint>) {
+    allowedPrivateHosts.store(peers.map { it.host }.toSet())
+  }
+
+  fun accept(connection: TorrentConnection): Boolean {
+    if (_state.value != TorrentSessionState.DOWNLOADING &&
+      _state.value != TorrentSessionState.SEEDING) return false
+    if (store.metadata.isPrivate && connection.remote.host !in allowedPrivateHosts.load()) return false
+    return incoming.trySend(connection).isSuccess
+  }
+
+  suspend fun resetPeers() {
+    val done = CompletableDeferred<Unit>()
+    resets.send(done)
+    done.await()
+  }
+
   private val rate = TorrentRateLimiter()
+  private val uploadRate = TorrentRateLimiter()
   private val connectionLimit = AtomicInt(connections)
   private val received = AtomicLong(checkpoint?.receivedBytes ?: 0)
   private val uploaded = AtomicLong(checkpoint?.uploadedBytes ?: 0)
@@ -104,7 +130,7 @@ internal class KotlinTorrentSession(
             try { discover(peers, this@KotlinTorrentSession) } finally { peers.close() }
           }
           try {
-            TorrentSwarm(store, network, budget,
+            TorrentSwarm(store, network, budget, peerId = peerId,
               connections = { connectionLimit.load() }, uploadPolicy = uploadPolicy,
               downloadPayload = { bytes ->
                 val total = received.fetchAndAdd(bytes.toLong()) + bytes
@@ -121,6 +147,7 @@ internal class KotlinTorrentSession(
                 downloadThrottle(bytes)
               },
               uploadPayload = { bytes ->
+                uploadRate.acquire(bytes)
                 uploadThrottle(bytes)
                 uploaded.fetchAndAdd(bytes.toLong())
               },
@@ -131,7 +158,7 @@ internal class KotlinTorrentSession(
                   TorrentSessionState.SEEDING
                 } else TorrentSessionState.FINISHED
               },
-            ).run(peers)
+            ).run(peers, incoming, resets)
           } finally {
             withContext(NonCancellable) { discovery.cancelAndJoin(); peers.cancel() }
           }
@@ -149,6 +176,7 @@ internal class KotlinTorrentSession(
     if (closed) return@withLock
     job?.cancelAndJoin()
     job = null
+    while (true) (incoming.tryReceive().getOrNull() ?: break).close()
     _state.value = TorrentSessionState.PAUSED
     currentSpeed.store(0)
     if (store.isInitialized()) store.persistCheckpoint(received.load(), uploaded.load())
@@ -159,6 +187,8 @@ internal class KotlinTorrentSession(
   } else null
 
   override fun setDownloadRateLimit(bytesPerSecond: Long) = rate.set(bytesPerSecond)
+
+  fun setUploadRateLimit(value: Long) = uploadRate.set(value)
 
   fun setConnections(value: Int) {
     require(value in 1..512)
@@ -178,6 +208,8 @@ internal class KotlinTorrentSession(
     job?.cancelAndJoin()
     job = null
     scope.cancel()
+    incoming.cancel()
+    resets.cancel()
     _state.value = TorrentSessionState.STOPPED
     if (deleteFiles) {
       if (!recovered) checkpoint?.let { store.restore(it) }

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConfig.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConfig.kt
@@ -22,6 +22,14 @@ data class TorrentConfig(
   val connectionsPerTorrent: Int = 100,
   val enableUpload: Boolean = false,
   val listenPort: Int = 0,
+  /** Total TCP connections, including metadata requests and incoming peers. */
+  val maxConnections: Int = 200,
+  /** Optional directory for DHT routing snapshots. Contains no task payload. */
+  val stateDirectory: String? = null,
+  /** Bootstrap endpoints in host:port or [IPv6]:port form. */
+  val dhtBootstrap: List<String> = listOf(
+    "router.bittorrent.com:6881", "router.utorrent.com:6881", "dht.transmissionbt.com:6881"
+  ),
   /** Explicit policy; null preserves the legacy [enableUpload] setting. */
   val uploadPolicy: TorrentUploadPolicy? = null,
   /** Maximum metainfo bytes accepted from HTTP or peers. */
@@ -32,10 +40,12 @@ data class TorrentConfig(
 ) {
   init {
     require(maxActiveTorrents > 0) { "maxActiveTorrents must be positive" }
-    require(connectionsPerTorrent > 0) { "connectionsPerTorrent must be positive" }
+    require(connectionsPerTorrent in 1..512)
+    require(maxConnections in 1..4096)
+    require(dhtBootstrap.size <= 64)
     require(metadataTimeoutSeconds >= 0) { "metadata timeout must be non-negative" }
     require(listenPort in 0..65535) { "listenPort must be in 0..65535" }
-    require(maxMetadataBytes > 0) { "maxMetadataBytes must be positive" }
+    require(maxMetadataBytes in 1..4 * 1024 * 1024)
     require(maxBufferedBytes >= 16384) { "maxBufferedBytes must hold a protocol block" }
   }
 

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConnectionBudget.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentConnectionBudget.kt
@@ -1,0 +1,83 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.delay
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+
+/** Counts live TCP sockets across sessions, including handshakes and metadata fetches. */
+@OptIn(ExperimentalAtomicApi::class)
+internal class TorrentConnectionBudget(
+  private val delegate: TorrentNetwork,
+  initialLimit: Int,
+) : TorrentNetwork by delegate {
+  private val limit = AtomicInt(initialLimit)
+  private val count = AtomicInt(0)
+  private val live = AtomicReference<List<TorrentConnection>>(emptyList())
+
+  fun set(value: Int) {
+    require(value in 1..4096)
+    limit.store(value)
+    live.load().drop(value).forEach { it.close() }
+  }
+
+  private fun reserve(): Boolean {
+    while (true) {
+      val current = count.load()
+      if (current >= limit.load()) return false
+      if (count.compareAndSet(current, current + 1)) return true
+    }
+  }
+
+  override suspend fun connect(remote: PeerEndpoint): TorrentConnection {
+    while (!reserve()) delay(25)
+    try {
+      return wrap(delegate.connect(remote))
+    } catch (e: Throwable) {
+      count.fetchAndAdd(-1)
+      throw e
+    }
+  }
+
+  override suspend fun listen(local: PeerEndpoint): TorrentListener {
+    val listener = delegate.listen(local)
+    return object : TorrentListener by listener {
+      override suspend fun accept(): TorrentConnection {
+        while (true) {
+          val connection = listener.accept()
+          if (reserve()) return wrap(connection)
+          connection.close()
+        }
+      }
+    }
+  }
+
+  private fun wrap(connection: TorrentConnection): TorrentConnection {
+    val closed = AtomicBoolean(false)
+    val wrapped = object : TorrentConnection by connection {
+      override fun close() {
+        if (closed.compareAndSet(false, true)) {
+          try { connection.close() } finally {
+            count.fetchAndAdd(-1)
+            while (true) {
+              val previous = live.load()
+              if (live.compareAndSet(previous, previous.filterNot { it === this })) break
+            }
+          }
+        }
+      }
+    }
+    while (true) {
+      val previous = live.load()
+      if (live.compareAndSet(previous, previous + wrapped)) break
+    }
+    if (count.load() > limit.load()) wrapped.close()
+    return wrapped
+  }
+
+  override fun close() {
+    live.exchange(emptyList()).forEach { it.close() }
+    delegate.close()
+  }
+}

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentDownloadSource.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentDownloadSource.kt
@@ -5,429 +5,302 @@ import com.linroid.ketch.api.KetchError
 import com.linroid.ketch.api.ResolvedSource
 import com.linroid.ketch.api.Segment
 import com.linroid.ketch.api.SourceFile
-import com.linroid.ketch.api.log.KetchLogger
 import com.linroid.ketch.core.engine.DownloadContext
 import com.linroid.ketch.core.engine.DownloadSource
+import com.linroid.ketch.core.engine.HttpEngine
 import com.linroid.ketch.core.engine.SourceResumeState
-import kotlin.io.encoding.Base64
+import io.ktor.http.Url
+import io.ktor.http.decodeURLPart
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.io.encoding.Base64
 
 /**
- * BitTorrent download source supporting `.torrent` files and
- * `magnet:` URIs.
- *
- * Uses libtorrent4j as the underlying engine on JVM and Android.
- * The engine manages its own file I/O, so [managesOwnFileIo] is
- * `true` — Ketch skips FileAccessor operations for torrent
- * downloads.
- *
- * Register with:
- * ```kotlin
- * Ketch(additionalSources = listOf(TorrentDownloadSource()))
- * ```
- *
- * @param config torrent engine configuration
+ * Pure Kotlin BitTorrent v1 source for JVM, Android, and iOS.
+ * Supports HTTP(S) metainfo, local paths/file URLs, metainfo bytes, and btih magnets.
+ * The optional HTTP engine remains owned by its caller. Output must be a filesystem path.
  */
+@OptIn(ExperimentalAtomicApi::class)
 class TorrentDownloadSource(
   private val config: TorrentConfig = TorrentConfig(),
+  httpEngine: HttpEngine? = null,
 ) : DownloadSource {
-
-  internal var engineFactory: () -> TorrentEngine = {
-    createTorrentEngine(config)
-  }
-
-  private val log = KetchLogger("TorrentSource")
-
+  private val httpDelegate = lazy { httpEngine?.let { TorrentHttp(it) } ?: TorrentHttp.default() }
+  private val http by httpDelegate
+  internal var engineFactory: () -> TorrentEngine = { KotlinTorrentEngine(config, http = http) }
+  private val engine = AtomicReference<TorrentEngine?>(null)
+  private val closed = AtomicBoolean(false)
+  private val engineMutex = Mutex()
+  private val tasks = TorrentSessionRegistry()
+  private val stateMutex = Mutex()
+  private val states = linkedMapOf<String, TorrentResumeState>()
   override val type: String = TYPE
-
   override val managesOwnFileIo: Boolean = true
 
-  private var engine: TorrentEngine? = null
-  private var activeSession: TorrentSession? = null
+  private suspend fun getEngine(): TorrentEngine = engineMutex.withLock {
+    check(!closed.load()) { "Torrent source is closed" }
+    engine.load()?.let { return@withLock it }
+    val created = engineFactory()
+    try {
+      created.start()
+      engine.store(created)
+      if (closed.load()) { engine.exchange(null)?.close(); error("Torrent source is closed") }
+      created
+    } catch (e: Throwable) { created.close(); throw e }
+  }
 
-  private suspend fun getEngine(): TorrentEngine {
-    val existing = engine
-    if (existing != null && existing.isRunning) return existing
-    val newEngine = engineFactory()
-    newEngine.start()
-    engine = newEngine
-    return newEngine
+  override fun close() {
+    if (closed.compareAndSet(false, true)) {
+      engine.exchange(null)?.close()
+      if (httpDelegate.isInitialized()) http.close()
+    }
+  }
+
+  /** Change the shared upload rate immediately; zero means unlimited. */
+  suspend fun setUploadRateLimit(bytesPerSecond: Long) {
+    require(bytesPerSecond >= 0)
+    getEngine().setUploadRateLimit(bytesPerSecond)
+  }
+
+  /** Change upload rate for an active task, including a completed task that is seeding. */
+  suspend fun setTaskUploadRateLimit(taskId: String, bytesPerSecond: Long) {
+    require(bytesPerSecond >= 0)
+    checkNotNull(tasks.session(taskId) as? KotlinTorrentSession) { "Torrent task is not active" }
+      .setUploadRateLimit(bytesPerSecond)
+  }
+
+  /** Change the shared TCP connection bound. Existing excess connections are closed. */
+  suspend fun setConnectionLimit(connections: Int) {
+    require(connections in 1..4096)
+    (getEngine() as KotlinTorrentEngine).setConnections(connections)
   }
 
   override fun canHandle(url: String): Boolean {
     val lower = url.lowercase()
-    return lower.startsWith("magnet:") ||
-      lower.endsWith(".torrent") ||
-      lower.contains(".torrent?")
+    return lower.startsWith("magnet:") || lower.startsWith("torrent:") ||
+      lower.substringBefore('?').substringBefore('#').endsWith(".torrent")
   }
 
-  override fun buildResumeState(
-    resolved: ResolvedSource,
-    totalBytes: Long,
-  ): SourceResumeState {
-    val infoHash = resolved.metadata[META_INFO_HASH] ?: ""
-    val state = TorrentResumeState(
-      infoHash = infoHash,
-      totalBytes = totalBytes,
-      resumeData = "",
-      selectedFileIds = resolved.files.map { it.id }.toSet(),
-      savePath = "",
-    )
-    return SourceResumeState(
-      sourceType = TYPE,
-      data = Json.encodeToString(state),
-    )
+  /** Resolve metainfo supplied by a file picker or SDK caller without making a network request. */
+  fun resolveMetainfo(bytes: ByteArray): ResolvedSource {
+    check(!closed.load()) { "Torrent source is closed" }
+    val metadata = TorrentMetadata.fromBencode(bytes, config.maxMetadataBytes)
+    return resolved("torrent:${metadata.infoHash.hex}", metadata)
   }
 
-  override suspend fun updateResumeState(
-    context: DownloadContext,
-  ): SourceResumeState? {
-    val session = activeSession ?: return null
-    val resumeData = session.saveResumeData() ?: return null
-    val selectedIds = context.request.selectedFileIds.ifEmpty {
-      context.segments.value.map { it.index.toString() }.toSet()
-    }
-    return SourceResumeState(
-      sourceType = TYPE,
-      data = Json.encodeToString(
-        TorrentResumeState(
-          infoHash = session.infoHash,
-          totalBytes = context.segments.value.sumOf { it.totalBytes },
-          resumeData = encodeBase64(resumeData),
-          selectedFileIds = selectedIds,
-          savePath = extractSavePath(context),
-        ),
-      ),
-    )
-  }
-
-  override suspend fun resolve(
-    url: String,
-    properties: Map<String, String>,
-  ): ResolvedSource {
-    val metadata = try {
-      resolveMetadata(url)
+  override suspend fun resolve(url: String, properties: Map<String, String>): ResolvedSource {
+    check(!closed.load()) { "Torrent source is closed" }
+    try {
+      val metadata = if (url.startsWith("magnet:", true)) {
+        getEngine().fetchMetadata(url) ?: throw KetchError.Network(
+          Exception("Torrent metadata resolution timed out"))
+      } else {
+        val bytes = if (url.startsWith("https://", true) || url.startsWith("http://", true)) {
+          http.fetch(url, config.maxMetadataBytes, headers = properties)
+        } else {
+          val path = if (url.startsWith("file:", true)) {
+            val parsed = Url(url)
+            require(parsed.host.isEmpty() || parsed.host == "localhost")
+            parsed.encodedPath.decodeURLPart()
+          } else {
+            require("://" !in url && !url.startsWith("torrent:")) {
+              "Metainfo bytes are required for this input"
+            }
+            url
+          }
+          withContext(Dispatchers.IO) {
+            FileSystem.SYSTEM.read(path.toPath()) {
+              val result = readByteArray(minOf(config.maxMetadataBytes.toLong(),
+                FileSystem.SYSTEM.metadata(path.toPath()).size ?: 0L))
+              require(exhausted()) { "Metainfo exceeds limit" }
+              result
+            }
+          }
+        }
+        TorrentMetadata.fromBencode(bytes, config.maxMetadataBytes)
+      }
+      return resolved(url, metadata)
+    } catch (e: CancellationException) { throw e
     } catch (e: Exception) {
-      if (e is CancellationException) throw e
       if (e is KetchError) throw e
       throw KetchError.SourceError(TYPE, e)
     }
-
-    val sourceFiles = metadata.files.map { file ->
-      SourceFile(
-        id = file.index.toString(),
-        name = file.path,
-        size = file.size,
-        metadata = mapOf("path" to file.path),
-      )
-    }
-
-    return ResolvedSource(
-      url = url,
-      sourceType = TYPE,
-      totalBytes = metadata.totalBytes,
-      supportsResume = true,
-      suggestedFileName = metadata.name,
-      maxSegments = metadata.files.size,
-      metadata = buildMap {
-        put(META_INFO_HASH, metadata.infoHash.hex)
-        put(META_NAME, metadata.name)
-        put(META_PIECE_LENGTH, metadata.pieceLength.toString())
-        metadata.comment?.let { put(META_COMMENT, it) }
-      },
-      files = sourceFiles,
-      selectionMode = FileSelectionMode.MULTIPLE,
-    )
   }
 
-  private suspend fun resolveMetadata(url: String): TorrentMetadata {
-    return if (url.lowercase().startsWith("magnet:")) {
-      val engine = getEngine()
-      log.i { "Fetching metadata from magnet URI" }
-      engine.fetchMetadata(url)
-        ?: throw KetchError.Network(
-          Exception("Metadata fetch timed out for: $url")
-        )
-    } else {
-      // .torrent URL — we expect pre-resolved metadata from
-      // torrent file bytes passed via DownloadRequest.resolvedSource
-      throw KetchError.SourceError(
-        TYPE,
-        Exception(
-          "Direct .torrent URL fetching not yet supported. " +
-            "Parse the .torrent file and pass metadata via " +
-            "DownloadRequest.resolvedSource"
-        ),
-      )
+  private fun resolved(url: String, metadata: TorrentMetadata): ResolvedSource = ResolvedSource(
+    url = url, sourceType = TYPE, totalBytes = metadata.totalBytes, supportsResume = true,
+    suggestedFileName = metadata.name, maxSegments = metadata.files.size,
+    metadata = buildMap {
+      put(META_INFO_HASH, metadata.infoHash.hex)
+      put(META_NAME, metadata.name)
+      put(META_PIECE_LENGTH, metadata.pieceLength.toString())
+      put(META_METAINFO, encodeBase64(metadata.metainfoBytes))
+      metadata.comment?.let { put(META_COMMENT, it) }
+    },
+    files = metadata.files.map { SourceFile(it.index.toString(), it.path, it.size,
+      metadata = mapOf("path" to it.path)) },
+    selectionMode = FileSelectionMode.MULTIPLE,
+  )
+
+  override fun buildResumeState(resolved: ResolvedSource, totalBytes: Long): SourceResumeState =
+    encode(TorrentResumeState(resolved.metadata[META_INFO_HASH] ?: "", totalBytes, "",
+      resolved.files.map { it.id }.toSet(), "", resolved.metadata[META_METAINFO] ?: ""))
+
+  override suspend fun updateResumeState(context: DownloadContext): SourceResumeState? {
+    val owner = tasks.session(context.taskId)
+    val saved = owner?.saveResumeData()
+    return stateMutex.withLock {
+      val state = states[context.taskId] ?: return@withLock null
+      val updated = if (saved != null) state.copy(resumeData = encodeBase64(saved)) else state
+      if (owner == null) states.remove(context.taskId) else states[context.taskId] = updated
+      encode(updated)
     }
   }
 
   override suspend fun download(context: DownloadContext) {
-    val resolved = context.preResolved
-      ?: resolve(context.url, context.headers)
-
-    val infoHash = resolved.metadata[META_INFO_HASH]
-      ?: throw KetchError.SourceError(
-        TYPE, Exception("Missing info hash in resolved metadata")
-      )
-
-    val selectedFileIds = context.request.selectedFileIds
-    val selectedIndices = if (selectedFileIds.isNotEmpty()) {
-      selectedFileIds.mapNotNull { it.toIntOrNull() }.toSet()
-    } else {
-      // Select all files by default
-      resolved.files.indices.toSet()
-    }
-
-    val totalBytes = if (selectedFileIds.isNotEmpty()) {
-      resolved.files
-        .filter { it.id in selectedFileIds }
-        .sumOf { it.size }
-    } else {
-      resolved.totalBytes
-    }
-
-    // Create one segment per selected file
-    val segments = createFileSegments(resolved, selectedIndices)
-    context.segments.value = segments
-
-    val savePath = extractSavePath(context)
-
-    log.i {
-      "Starting torrent download: infoHash=$infoHash, " +
-        "files=${selectedIndices.size}, totalBytes=$totalBytes"
-    }
-
-    val engine = getEngine()
-    val magnetUri = if (
-      context.url.lowercase().startsWith("magnet:")
-    ) {
-      context.url
-    } else {
-      null
-    }
-
-    val session = try {
-      engine.addTorrent(
-        infoHash = infoHash,
-        savePath = savePath,
-        magnetUri = magnetUri,
-        selectedFileIndices = selectedIndices,
-      )
-    } catch (e: Exception) {
-      if (e is CancellationException) throw e
-      if (e is KetchError) throw e
-      throw KetchError.SourceError(TYPE, e)
-    }
-
-    // Apply speed limit if configured
-    val speedLimit = context.request.speedLimit
-    if (!speedLimit.isUnlimited) {
-      session.setDownloadRateLimit(speedLimit.bytesPerSecond)
-    }
-
-    activeSession = session
-    try {
-      monitorProgress(context, session, segments, totalBytes)
-    } catch (e: CancellationException) {
-      session.pause()
-      throw e
-    } catch (e: Exception) {
-      if (e is KetchError) throw e
-      throw KetchError.SourceError(TYPE, e)
-    } finally {
-      activeSession = null
-    }
+    val resolved = context.preResolved ?: resolve(context.url, context.headers)
+    execute(context, resolved, null)
   }
 
-  override suspend fun resume(
+  override suspend fun resume(context: DownloadContext, resumeState: SourceResumeState) {
+    val state = try { Json.decodeFromString<TorrentResumeState>(resumeState.data)
+    } catch (e: Exception) { throw KetchError.CorruptResumeState(e.message, e) }
+    val checkpoint = if (state.resumeData.isEmpty()) null else
+      TorrentCheckpoint.decode(decodeBase64(state.resumeData))
+    val resolved = when {
+      state.metainfo.isNotEmpty() -> resolveMetainfo(decodeBase64(state.metainfo))
+      checkpoint != null -> resolved(context.url, checkpoint.metadata)
+      else -> resolve(context.url, context.headers)
+    }
+    require(resolved.metadata[META_INFO_HASH] == state.infoHash) { "Resume torrent changed" }
+    execute(context, resolved, state)
+  }
+
+  private suspend fun execute(
     context: DownloadContext,
-    resumeState: SourceResumeState,
-  ) {
-    val state = try {
-      Json.decodeFromString<TorrentResumeState>(resumeState.data)
-    } catch (e: Exception) {
-      if (e is CancellationException) throw e
-      throw KetchError.CorruptResumeState(e.message, e)
-    }
-
-    log.i { "Resuming torrent: infoHash=${state.infoHash}" }
-
-    val resumeData = try {
-      decodeBase64(state.resumeData)
-    } catch (e: Exception) {
-      if (e is CancellationException) throw e
-      log.w(e) { "Failed to decode resume data, starting fresh" }
-      null
-    }
-
-    val selectedIndices = state.selectedFileIds
-      .mapNotNull { it.toIntOrNull() }
-      .toSet()
-
-    val engine = getEngine()
-    val magnetUri = if (
-      context.url.lowercase().startsWith("magnet:")
-    ) {
-      context.url
-    } else {
-      null
-    }
-
-    val session = try {
-      engine.addTorrent(
-        infoHash = state.infoHash,
-        savePath = state.savePath,
-        magnetUri = magnetUri,
-        selectedFileIndices = selectedIndices,
-        resumeData = resumeData,
-      )
-    } catch (e: Exception) {
-      if (e is CancellationException) throw e
-      if (e is KetchError) throw e
-      throw KetchError.SourceError(TYPE, e)
-    }
-
-    val speedLimit = context.request.speedLimit
-    if (!speedLimit.isUnlimited) {
-      session.setDownloadRateLimit(speedLimit.bytesPerSecond)
-    }
-
-    val segments = context.segments.value
-    val totalBytes = state.totalBytes
-
-    activeSession = session
-    try {
-      monitorProgress(context, session, segments, totalBytes)
-    } catch (e: CancellationException) {
-      session.pause()
-      throw e
-    } catch (e: Exception) {
-      if (e is KetchError) throw e
-      throw KetchError.SourceError(TYPE, e)
-    } finally {
-      activeSession = null
-    }
-  }
-
-  override suspend fun cleanup(
-    context: DownloadContext,
-    resumeState: SourceResumeState?,
-  ) {
-    if (resumeState == null) {
-      log.d { "Skipping torrent cleanup: no resume state" }
-      return
-    }
-    val state = try {
-      Json.decodeFromString<TorrentResumeState>(resumeState.data)
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      log.w(e) { "Skipping torrent cleanup: corrupt resume state" }
-      return
-    }
-    try {
-      getEngine().removeTorrent(state.infoHash, deleteFiles = true)
-      log.i { "Removed torrent and files: infoHash=${state.infoHash}" }
-    } catch (e: CancellationException) {
-      throw e
-    } catch (e: Throwable) {
-      log.w(e) {
-        "Failed to remove torrent infoHash=${state.infoHash}"
-      }
-    }
-  }
-
-  /**
-   * Monitors torrent download progress and maps it to Ketch
-   * segment progress until download completes or is canceled.
-   */
-  private suspend fun monitorProgress(
-    context: DownloadContext,
-    session: TorrentSession,
-    segments: List<Segment>,
-    totalBytes: Long,
-  ) {
-    // Wait for the download to complete
-    while (true) {
-      val sessionState = session.state.value
-      when (sessionState) {
-        TorrentSessionState.FINISHED,
-        TorrentSessionState.SEEDING -> break
-
-        TorrentSessionState.STOPPED -> {
-          throw KetchError.SourceError(
-            TYPE, Exception("Torrent session stopped unexpectedly")
-          )
-        }
-        else -> {
-          // Update progress
-          val downloaded = session.downloadedBytes.value
-            .coerceAtMost(totalBytes)
-          updateSegmentProgress(context, segments, downloaded, totalBytes)
-          context.onProgress(downloaded, totalBytes)
-          delay(PROGRESS_INTERVAL_MS)
-        }
-      }
-    }
-
-    // Final progress update
-    updateSegmentProgress(context, segments, totalBytes, totalBytes)
-    context.onProgress(totalBytes, totalBytes)
-  }
-
-  /**
-   * Distributes downloaded bytes across segments proportionally.
-   */
-  private fun updateSegmentProgress(
-    context: DownloadContext,
-    segments: List<Segment>,
-    downloaded: Long,
-    totalBytes: Long,
-  ) {
-    if (segments.isEmpty()) return
-    val fraction = if (totalBytes > 0) {
-      downloaded.toDouble() / totalBytes
-    } else {
-      0.0
-    }
-    val updated = segments.map { segment ->
-      val segDownloaded = (segment.totalBytes * fraction)
-        .toLong()
-        .coerceAtMost(segment.totalBytes)
-      segment.copy(downloadedBytes = segDownloaded)
-    }
-    context.segments.value = updated
-  }
-
-  private fun createFileSegments(
     resolved: ResolvedSource,
-    selectedIndices: Set<Int>,
-  ): List<Segment> {
-    var offset = 0L
-    val segments = mutableListOf<Segment>()
-    for (file in resolved.files) {
-      val fileIndex = file.id.toIntOrNull() ?: continue
-      if (fileIndex !in selectedIndices) continue
-      segments.add(
-        Segment(
-          index = segments.size,
-          start = offset,
-          end = offset + file.size - 1,
-          downloadedBytes = 0,
-        )
-      )
-      offset += file.size
+    previous: TorrentResumeState?,
+  ) {
+    val hash = requireNotNull(resolved.metadata[META_INFO_HASH])
+    val bytes = decodeBase64(requireNotNull(resolved.metadata[META_METAINFO]))
+    val metadata = TorrentMetadata.fromBencode(bytes, config.maxMetadataBytes)
+    require(metadata.infoHash.hex == hash) { "Resolved torrent hash mismatch" }
+    val selectedIds = previous?.selectedFileIds ?: context.request.selectedFileIds
+    val selected = if (selectedIds.isEmpty()) metadata.files.indices.toSet() else {
+      selectedIds.map { id ->
+        requireNotNull(id.toIntOrNull()).also { require(it in metadata.files.indices) }
+      }.toSet()
     }
-    return segments
+    val output = context.outputPath ?: previous?.savePath?.takeIf { it.isNotEmpty() }
+      ?: error("Torrent output path has not been resolved")
+    require(!output.contains("://")) { "Torrent output requires a filesystem path" }
+    val total = metadata.files.filter { it.index in selected }.sumOf { it.size }
+    val state = TorrentResumeState(hash, total, previous?.resumeData ?: "",
+      selected.map { it.toString() }.toSet(), output, encodeBase64(bytes))
+    tasks.reserve(context.taskId, hash)
+    var session: TorrentSession? = null
+    var keepSeeding = false
+    try {
+      stateMutex.withLock {
+        // Finished snapshots are bounded; persisted task state and the ownership journal recover
+        // tasks after eviction. Active entries must remain until the final core snapshot.
+        while (states.size >= 64) states.remove(states.keys.first())
+        states[context.taskId] = state
+      }
+      val runtime = getEngine()
+      session = runtime.addTask(TorrentTaskSpec(context.taskId, metadata, output, selected,
+        context.url.takeIf { it.startsWith("magnet:", true) },
+        previous?.resumeData?.takeIf { it.isNotEmpty() }?.let(::decodeBase64), context.throttle))
+      tasks.attach(context.taskId, session)
+      coroutineScope {
+        val connections = launch {
+          context.maxConnections.collect { value ->
+            (session as? KotlinTorrentSession)?.setConnections(
+              if (value > 0) value.coerceAtMost(512) else config.connectionsPerTorrent)
+          }
+        }
+        try {
+          session.resume()
+          while (true) {
+            val currentState = session.state.value
+            val progress = (session as? KotlinTorrentSession)?.fileProgress()
+              ?: LongArray(metadata.files.size)
+            var offset = 0L
+            context.segments.value = metadata.files.filter { it.index in selected }.map { file ->
+              Segment(file.index, offset, offset + file.size - 1,
+                progress[file.index]).also { offset += file.size }
+            }
+            context.reportedSpeed.value = session.downloadSpeed
+            context.onProgress(context.segments.value.sumOf { it.downloadedBytes }, total)
+            when (currentState) {
+              TorrentSessionState.FINISHED -> break
+              TorrentSessionState.SEEDING -> { keepSeeding = true; break }
+              TorrentSessionState.STOPPED -> throw ((session as? KotlinTorrentSession)
+                ?.failure?.value ?: error("Torrent session stopped"))
+              else -> delay(200)
+            }
+          }
+        } finally { connections.cancel() }
+      }
+    } catch (e: CancellationException) { throw e
+    } catch (e: Exception) { throw KetchError.SourceError(TYPE, e)
+    } finally {
+      withContext(NonCancellable) {
+        try {
+          if (!keepSeeding) session?.pause()
+          updateResumeState(context)
+        } finally {
+          if (!keepSeeding) {
+            engine.load()?.removeTorrent(hash)
+            tasks.release(context.taskId)
+          }
+        }
+      }
+    }
   }
 
-  private fun extractSavePath(context: DownloadContext): String {
-    val dest = context.request.destination
-    return dest?.value ?: "downloads"
+  override suspend fun cleanup(context: DownloadContext, resumeState: SourceResumeState?) {
+    if (resumeState == null) return
+    try {
+      val state = Json.decodeFromString<TorrentResumeState>(resumeState.data)
+      if (tasks.session(context.taskId) != null) {
+        engine.load()?.removeTorrent(state.infoHash, deleteFiles = true)
+      }
+      tasks.release(context.taskId)
+      val checkpoint = state.resumeData.takeIf { it.isNotEmpty() }
+        ?.let { TorrentCheckpoint.decode(decodeBase64(it)) }
+      val metadata = checkpoint?.metadata ?: state.metainfo.takeIf { it.isNotEmpty() }
+        ?.let { TorrentMetadata.fromBencode(decodeBase64(it)) } ?: return
+      val output = context.outputPath ?: checkpoint?.output ?: state.savePath
+      if (output.isEmpty()) return
+      val store = TorrentPieceStore(metadata, output.toPath(),
+        state.selectedFileIds.map { it.toInt() }.toSet(), context.taskId)
+      checkpoint?.let { store.restore(it) }
+      store.recoverOwnership()
+      store.cleanup()
+      stateMutex.withLock { states.remove(context.taskId) }
+    } catch (e: CancellationException) { throw e
+    } catch (_: Exception) {
+      // Unknown or legacy ownership is conservatively preserved.
+    }
   }
+
+  private fun encode(state: TorrentResumeState): SourceResumeState =
+    SourceResumeState(TYPE, Json.encodeToString(state))
 
   companion object {
     const val TYPE = "torrent"
@@ -435,7 +308,7 @@ class TorrentDownloadSource(
     internal const val META_NAME = "name"
     internal const val META_PIECE_LENGTH = "pieceLength"
     internal const val META_COMMENT = "comment"
-    private const val PROGRESS_INTERVAL_MS = 500L
+    internal const val META_METAINFO = "metainfo"
 
     fun buildResumeState(
       infoHash: String,

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentEngine.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentEngine.kt
@@ -14,6 +14,8 @@ internal interface TorrentEngine {
   /** Stops the engine and releases all resources. */
   suspend fun stop()
 
+  fun close() {}
+
   /** Whether the engine is currently running. */
   val isRunning: Boolean
 
@@ -47,6 +49,11 @@ internal interface TorrentEngine {
     resumeData: ByteArray? = null,
   ): TorrentSession
 
+  suspend fun addTask(spec: TorrentTaskSpec): TorrentSession = addTorrent(
+    spec.metadata.infoHash.hex, spec.outputPath, spec.magnetUri, spec.metadata.metainfoBytes,
+    spec.selected, spec.resumeData
+  )
+
   /**
    * Removes a torrent from the engine.
    *
@@ -72,3 +79,13 @@ internal interface TorrentEngine {
    */
   fun setUploadRateLimit(bytesPerSecond: Long)
 }
+
+internal data class TorrentTaskSpec(
+  val taskId: String,
+  val metadata: TorrentMetadata,
+  val outputPath: String,
+  val selected: Set<Int>,
+  val magnetUri: String? = null,
+  val resumeData: ByteArray? = null,
+  val throttle: suspend (Int) -> Unit = {},
+)

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentResumeState.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentResumeState.kt
@@ -18,4 +18,6 @@ internal data class TorrentResumeState(
   val resumeData: String,
   val selectedFileIds: Set<String>,
   val savePath: String,
+  val metainfo: String = "",
+  val version: Int = 1,
 )

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TorrentSwarm.kt
@@ -1,5 +1,7 @@
 package com.linroid.ketch.torrent
 
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -42,8 +44,13 @@ internal class TorrentSwarm(
   private val connected = mutableMapOf<Int, PeerEndpoint>()
 
   /** A closed peer stream fails once every candidate has exhausted its bounded retries. */
-  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-  suspend fun run(peers: ReceiveChannel<PeerEndpoint>) = supervisorScope {
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class,
+    kotlinx.coroutines.DelicateCoroutinesApi::class)
+  suspend fun run(
+    peers: ReceiveChannel<PeerEndpoint>,
+    incoming: ReceiveChannel<TorrentConnection>? = null,
+    resets: ReceiveChannel<CompletableDeferred<Unit>>? = null,
+  ) = supervisorScope {
     store.initialize()
     if (store.completed() && uploadPolicy != TorrentUploadPolicy.SEED_AFTER_COMPLETION) {
       store.finish()
@@ -78,6 +85,32 @@ internal class TorrentSwarm(
           attempts.size + pending.size < 4096) pending.addLast(endpoint)
       }
     }
+    fun launchPeer(
+      endpoint: PeerEndpoint,
+      overhead: TorrentBufferBudget.Lease,
+      connection: TorrentConnection? = null,
+    ) {
+      val id = nextId++
+      attempts[endpoint] = (attempts[endpoint] ?: 0) + 1
+      active[endpoint] = launch(Dispatchers.Default, start = CoroutineStart.ATOMIC) {
+        var failure: Throwable? = null
+        try {
+          peer(id, endpoint, scheduler, progressEvents, pexEvents, connection)
+        } catch (e: CancellationException) {
+          throw e
+        } catch (e: Exception) {
+          failure = e
+        } finally {
+          withContext(NonCancellable) {
+            scheduler.remove(id)
+            connectedMutex.withLock { connected.remove(id) }
+          }
+          connection?.close()
+          overhead.close()
+          results.trySend(endpoint to failure)
+        }
+      }
+    }
     try {
       while (currentCoroutineContext().isActive) {
         // A terminating introducer may have queued its last PEX before its result was selected.
@@ -106,31 +139,32 @@ internal class TorrentSwarm(
             pending.addFirst(endpoint)
             break
           }
-          val id = nextId++
-          attempts[endpoint] = (attempts[endpoint] ?: 0) + 1
-          active[endpoint] = launch(Dispatchers.Default) {
-            var failure: Throwable? = null
-            try {
-              peer(id, endpoint, scheduler, progressEvents, pexEvents)
-            } catch (e: CancellationException) {
-              throw e
-            } catch (e: Exception) {
-              failure = e
-            } finally {
-              withContext(NonCancellable) {
-                scheduler.remove(id)
-                connectedMutex.withLock { connected.remove(id) }
-              }
-              overhead.close()
-              results.trySend(endpoint to failure)
-            }
-          }
+          launchPeer(endpoint, overhead)
         }
-        if (discoveryClosed && pending.isEmpty() && active.isEmpty()) {
+        if (discoveryClosed && pending.isEmpty() && active.isEmpty() && incoming == null) {
           check(complete) { "No peer could complete the torrent" }
           break
         }
         select<Unit> {
+          incoming?.onReceive { connection ->
+            val overhead = if (active.size < limit && connection.remote !in active) {
+              budget.reserve(256 * 1024 + store.pieceCount * 4)
+            } else null
+            if (overhead == null) connection.close()
+            else launchPeer(connection.remote, overhead, connection)
+          }
+          resets?.onReceive { done ->
+            active.values.forEach { it.cancel() }
+            active.values.forEach { it.join() }
+            active.clear()
+            while (results.tryReceive().isSuccess) { }
+            while (peers.tryReceive().isSuccess) { }
+            while (true) (incoming?.tryReceive()?.getOrNull() ?: break).close()
+            pending.clear()
+            attempts.clear()
+            retryAt.clear()
+            done.complete(Unit)
+          }
           if (!discoveryClosed) peers.onReceiveCatching { result ->
             val endpoint = result.getOrNull()
             if (endpoint == null) discoveryClosed = true
@@ -167,9 +201,10 @@ internal class TorrentSwarm(
     scheduler: TorrentPieceScheduler,
     progressEvents: SendChannel<Unit>,
     pexEvents: SendChannel<Pair<PeerEndpoint, PexUpdate>>,
+    accepted: TorrentConnection? = null,
   ) =
     supervisorScope {
-      val connection = network.connect(endpoint)
+      val connection = accepted ?: network.connect(endpoint)
       var uploadSlot = false
       val uploadCache = TorrentUploadCache(store, budget)
       try {

--- a/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TrackerDiscovery.kt
+++ b/library/torrent/src/commonMain/kotlin/com/linroid/ketch/torrent/TrackerDiscovery.kt
@@ -10,6 +10,7 @@ internal class TrackerDiscovery(
   private val trackers: TrackerTiers,
   private val onPrivateTrackerChanged: suspend () -> Unit = {},
   private val nowMs: () -> Long = monotonicClock(),
+  private val announceCompletion: Boolean = true,
 ) {
   init { if (metadata.isPrivate) trackers.preferCurrentTracker() }
 
@@ -34,7 +35,7 @@ internal class TrackerDiscovery(
       stopped && started -> TrackerEvent.STOPPED
       stopped -> return null
       !started -> TrackerEvent.STARTED
-      left == 0L && !completed -> TrackerEvent.COMPLETED
+      left == 0L && !completed && announceCompletion -> TrackerEvent.COMPLETED
       else -> TrackerEvent.NONE
     }
     if (event == TrackerEvent.NONE && nowMs() < nextAnnounce) return null

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/KotlinTorrentEngineTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/KotlinTorrentEngineTest.kt
@@ -1,0 +1,57 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+class KotlinTorrentEngineTest {
+  @Test
+  fun completedTorrent_acceptsNewIncomingPeerAndSeedsVerifiedBytes() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(15_000) {
+        val bytes = byteArrayOf(8, 9, 10, 11)
+        val metadata = TorrentMetadata.fromBencode(Bencode.encode(mapOf("info" to mapOf(
+          "name" to "seed", "length" to 4L, "piece length" to 4L, "pieces" to sha1Digest(bytes)
+        ))))
+        val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+          "ketch-incoming-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+        FileSystem.SYSTEM.createDirectories(root)
+        FileSystem.SYSTEM.write(root / "seed") { write(bytes) }
+        val engine = KotlinTorrentEngine(TorrentConfig(dhtEnabled = false,
+          uploadPolicy = TorrentUploadPolicy.SEED_AFTER_COMPLETION))
+        val remote = createTorrentNetwork()
+        try {
+          engine.start()
+          val session = engine.addTask(TorrentTaskSpec("seed-task", metadata,
+            (root / "seed").toString(), emptySet()))
+          session.resume()
+          val state = session.state.first {
+            it == TorrentSessionState.SEEDING || it == TorrentSessionState.STOPPED
+          }
+          assertEquals(TorrentSessionState.SEEDING, state, session.failure.value?.stackTraceToString())
+          val connection = remote.connect(PeerEndpoint("127.0.0.1", engine.listenPort))
+          try {
+            val wire = PeerWire(connection, metadata)
+            wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+            wire.send(PeerMessage.Control(PeerMessage.Signal.INTERESTED))
+            while (wire.read() != PeerMessage.Control(PeerMessage.Signal.UNCHOKE)) { }
+            wire.send(PeerMessage.Request(0, 0, 4))
+            var message = wire.read()
+            while (message !is PeerMessage.Piece) message = wire.read()
+            assertContentEquals(bytes, message.bytes)
+          } finally { connection.close() }
+        } finally {
+          engine.stop()
+          remote.close()
+          FileSystem.SYSTEM.deleteRecursively(root, mustExist = false)
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/KotlinTorrentSourceTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/KotlinTorrentSourceTest.kt
@@ -1,0 +1,150 @@
+package com.linroid.ketch.torrent
+
+import com.linroid.ketch.api.DownloadRequest
+import com.linroid.ketch.api.ResolvedSource
+import com.linroid.ketch.core.engine.DownloadContext
+import com.linroid.ketch.core.engine.HttpEngine
+import com.linroid.ketch.core.engine.ServerInfo
+import com.linroid.ketch.core.file.FileAccessor
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.IOException
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KotlinTorrentSourceTest {
+  private object NoOpFileAccessor : FileAccessor {
+    override suspend fun writeAt(offset: Long, data: ByteArray): Unit = error("Source owns I/O")
+    override suspend fun flush(): Unit = error("Source owns I/O")
+    override fun close() = Unit
+    override suspend fun delete(): Unit = error("Source owns I/O")
+    override suspend fun size(): Long = error("Source owns I/O")
+    override suspend fun preallocate(size: Long): Unit = error("Source owns I/O")
+  }
+
+  private class Http(val metainfo: ByteArray, val peer: PeerEndpoint) : HttpEngine {
+    var closed = false
+    val events = mutableListOf<String>()
+    override suspend fun head(url: String, headers: Map<String, String>): ServerInfo = error("unused")
+    override suspend fun download(
+      url: String,
+      range: LongRange?,
+      headers: Map<String, String>,
+      onData: suspend (ByteArray) -> Unit,
+    ) {
+      if (url.contains(".torrent")) onData(metainfo) else {
+        events += url.substringAfter("event=", "").substringBefore('&')
+        onData(Bencode.encode(mapOf("interval" to 30L, "peers" to listOf(
+          mapOf("ip" to peer.host, "port" to peer.port.toLong())
+        ))))
+      }
+    }
+    override fun close() { closed = true }
+  }
+
+  @Test
+  fun selectedBoundaryFiles_downloadAndRestartThroughPublicSource() = runTest {
+    withContext(Dispatchers.Default) {
+      withTimeout(20_000) {
+        coroutineScope {
+          val network = createTorrentNetwork()
+          val listener = network.listen(PeerEndpoint("127.0.0.1", 0))
+          val bytes = ByteArray(8) { it.toByte() }
+          val metainfo = Bencode.encode(mapOf("announce" to "http://tracker/announce",
+            "info" to mapOf("name" to "bundle", "piece length" to 4L,
+              "pieces" to sha1Digest(bytes.copyOfRange(0, 4)) +
+                sha1Digest(bytes.copyOfRange(4, 8)),
+              "files" to listOf(
+                mapOf("length" to 3L, "path" to listOf("skip-a")),
+                mapOf("length" to 2L, "path" to listOf("selected")),
+                mapOf("length" to 3L, "path" to listOf("skip-b"))
+              ))))
+          val metadata = TorrentMetadata.fromBencode(metainfo)
+          val http = Http(metainfo, listener.local)
+          val source = TorrentDownloadSource(TorrentConfig(dhtEnabled = false), http)
+          val root = FileSystem.SYSTEM_TEMPORARY_DIRECTORY /
+            "ketch-source-${InfoHash.fromBytes(torrentRandomBytes(20)).hex}"
+          val output = root / "custom-name"
+          val server = launch {
+            while (isActive) {
+              val connection = listener.accept()
+              launch {
+                try {
+                  val wire = PeerWire(connection, metadata)
+                  wire.handshake(PeerHandshake(metadata.infoHash, torrentRandomBytes(20), false, false))
+                  wire.send(PeerMessage.Bitfield(byteArrayOf(192.toByte())))
+                  wire.send(PeerMessage.Control(PeerMessage.Signal.UNCHOKE))
+                  while (true) {
+                    val message = wire.read()
+                    if (message is PeerMessage.Request) {
+                      val begin = message.index * 4 + message.begin
+                      wire.send(PeerMessage.Piece(message.index, message.begin,
+                        bytes.copyOfRange(begin, begin + message.length)))
+                    }
+                  }
+                } catch (_: IOException) {
+                  // The completed downloader closes its peer socket.
+                } finally { connection.close() }
+              }
+            }
+          }
+          fun context(resolved: ResolvedSource?) = DownloadContext(
+            taskId = "selected-task", url = "http://fixture/bundle.torrent",
+            request = DownloadRequest(url = "http://fixture/bundle.torrent",
+              selectedFileIds = setOf("1")),
+            fileAccessor = NoOpFileAccessor, segments = MutableStateFlow(emptyList()),
+            onProgress = { downloaded, total ->
+              assertEquals(2L, total)
+              assertTrue(downloaded in 0..2)
+            },
+            throttle = {}, headers = emptyMap(), preResolved = resolved,
+            outputPath = output.toString(),
+          )
+          try {
+            val resolved = source.resolve("http://fixture/bundle.torrent", emptyMap())
+            assertEquals(8L, resolved.totalBytes)
+            val first = context(resolved)
+            source.download(first)
+            assertEquals(listOf(1), first.segments.value.map { it.index })
+            assertEquals(2L, first.segments.value.single().downloadedBytes)
+            assertContentEquals(byteArrayOf(3, 4),
+              FileSystem.SYSTEM.read(output / "selected") { readByteArray() })
+            assertFalse(FileSystem.SYSTEM.exists(output / "skip-a"))
+            assertFalse(FileSystem.SYSTEM.exists(output / "skip-b"))
+            assertFalse("completed" in http.events) // Only a subset of the torrent is present.
+            val saved = assertNotNull(source.updateResumeState(first))
+            source.close()
+            server.cancelAndJoin()
+            network.close()
+            val restored = TorrentDownloadSource(TorrentConfig(dhtEnabled = false))
+            try {
+              val second = context(null)
+              restored.resume(second, saved)
+              assertEquals(2L, second.segments.value.single().downloadedBytes)
+              restored.cleanup(second, assertNotNull(restored.updateResumeState(second)))
+              assertFalse(FileSystem.SYSTEM.exists(output / "selected"))
+            } finally { restored.close() }
+            assertFalse(http.closed)
+          } finally {
+            source.close()
+            server.cancelAndJoin()
+            network.close()
+            FileSystem.SYSTEM.deleteRecursively(root, mustExist = false)
+          }
+        }
+      }
+    }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentConnectionBudgetTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentConnectionBudgetTest.kt
@@ -1,0 +1,48 @@
+package com.linroid.ketch.torrent
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TorrentConnectionBudgetTest {
+  @Test
+  fun liveReductionClosesExcessAndWaitingConnectRespectsNewBound() = runTest {
+    val sockets = mutableListOf<FakeConnection>()
+    val network = object : TorrentNetwork {
+      override suspend fun connect(remote: PeerEndpoint): TorrentConnection =
+        FakeConnection(remote).also { sockets += it }
+      override suspend fun listen(local: PeerEndpoint): TorrentListener = error("unused")
+      override suspend fun bindUdp(local: PeerEndpoint): TorrentDatagramSocket = error("unused")
+      override fun close() { sockets.forEach { it.close() } }
+    }
+    val bounded = TorrentConnectionBudget(network, 2)
+    val first = bounded.connect(PeerEndpoint("127.0.0.1", 1))
+    bounded.connect(PeerEndpoint("127.0.0.1", 2))
+    val pending = async { bounded.connect(PeerEndpoint("127.0.0.1", 3)) }
+    delay(100)
+    assertEquals(2, sockets.size)
+    bounded.set(1)
+    assertTrue(sockets[1].closed)
+    assertFalse(sockets[0].closed)
+    delay(100)
+    assertFalse(pending.isCompleted)
+    first.close()
+    pending.await().close()
+    assertEquals(3, sockets.size)
+    bounded.close()
+    assertTrue(sockets.all { it.closed })
+    pending.cancelAndJoin()
+  }
+
+  private class FakeConnection(override val remote: PeerEndpoint) : TorrentConnection {
+    var closed = false
+    override suspend fun readExactly(size: Int): ByteArray = error("unused")
+    override suspend fun write(bytes: ByteArray) = Unit
+    override fun close() { closed = true }
+  }
+}

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentDownloadSourceCleanupTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentDownloadSourceCleanupTest.kt
@@ -54,15 +54,14 @@ class TorrentDownloadSourceCleanupTest {
     )
 
   @Test
-  fun cleanup_callsRemoveTorrentWithDeleteFilesTrue() = runTest {
+  fun cleanup_legacyStateDoesNotStartEngineOrGuessOwnership() = runTest {
     val engine = FakeTorrentEngine()
     val source = buildSource(engine)
 
     source.cleanup(buildContext(), resumeStateFor(infoHash))
 
-    assertEquals(1, engine.removedTorrents.size)
-    assertEquals(infoHash, engine.removedTorrents[0].first)
-    assertEquals(true, engine.removedTorrents[0].second)
+    assertTrue(engine.removedTorrents.isEmpty())
+    assertTrue(!engine.started)
   }
 
   @Test
@@ -94,7 +93,7 @@ class TorrentDownloadSourceCleanupTest {
     // Must not propagate.
     source.cleanup(buildContext(), resumeStateFor(infoHash))
 
-    assertEquals(1, engine.removeAttempts)
+    assertEquals(0, engine.removeAttempts)
   }
 
   private class ThrowingFakeEngine : TorrentEngine {

--- a/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentDownloadSourceResolveTest.kt
+++ b/library/torrent/src/commonTest/kotlin/com/linroid/ketch/torrent/TorrentDownloadSourceResolveTest.kt
@@ -146,18 +146,6 @@ class TorrentDownloadSourceResolveTest {
 
   // -- resolve via .torrent URL --
 
-  @Test
-  fun resolve_torrentUrl_throwsSourceError() = runTest {
-    // Direct .torrent URL fetching is not yet supported
-    val error = assertFailsWith<KetchError.SourceError> {
-      source.resolve(
-        "https://example.com/file.torrent",
-        emptyMap(),
-      )
-    }
-    assertEquals("torrent", error.sourceType)
-  }
-
   // -- Engine lifecycle --
 
   @Test

--- a/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PlatformActuals.ios.kt
+++ b/library/torrent/src/iosMain/kotlin/com/linroid/ketch/torrent/PlatformActuals.ios.kt
@@ -1,13 +1,4 @@
 package com.linroid.ketch.torrent
 
-import com.linroid.ketch.api.KetchError
-
-internal actual fun createTorrentEngine(
-  config: TorrentConfig,
-): TorrentEngine {
-  throw KetchError.Unsupported(
-    cause = UnsupportedOperationException(
-      "BitTorrent is not yet supported on iOS"
-    ),
-  )
-}
+internal actual fun createTorrentEngine(config: TorrentConfig): TorrentEngine =
+  KotlinTorrentEngine(config)

--- a/library/torrent/src/jvmMain/kotlin/com/linroid/ketch/torrent/PlatformActuals.jvm.kt
+++ b/library/torrent/src/jvmMain/kotlin/com/linroid/ketch/torrent/PlatformActuals.jvm.kt
@@ -1,8 +1,4 @@
 package com.linroid.ketch.torrent
 
-internal actual fun createTorrentEngine(
-  config: TorrentConfig,
-): TorrentEngine {
-  NativeLibraryLoader.ensureLoaded()
-  return createLibtorrent4jEngine(config)
-}
+internal actual fun createTorrentEngine(config: TorrentConfig): TorrentEngine =
+  KotlinTorrentEngine(config)


### PR DESCRIPTION
Switch the default torrent backend to the common Kotlin runtime on JVM, Android, and iOS, and register torrent support in CLI download and daemon modes. The existing Android, desktop, and iOS registrations now use the same implementation.

The source accepts HTTP(S) metainfo, local paths/file URLs, SDK metainfo bytes, and magnets. Task-specific ownership replaces the single active session; selected-file progress comes from verified storage, payload speed is reported separately, and cancellation saves a final checkpoint before releasing the session. Resume rehashes output; offline cleanup uses recorded ownership. Incoming peers, persistent seeding, tracker lifecycle/private tracker changes, DHT bootstrap/warm snapshots, shared connection bounds, and live upload controls are wired into the runtime.

Validation: JVM, Android host, and real iOS simulator torrent/core suites; CLI compilation. New integration fixtures cover a selected file spanning two pieces, offline restart and cleanup, incoming seeding after completion, connection-limit reduction, and zero-byte selection plus final checkpoint persistence on cancellation.

Stack: depends on #159. Native implementation/dependencies remain temporarily for reference testing; final interoperability, filesystem race hardening, performance/artifact gates, and native removal belong to layer 14. No merge or release is part of this PR.
